### PR TITLE
Исправление начисление баланса с ивента и возвращение Зари двух видов

### DIFF
--- a/Resources/Maps/Corvax/Shuttles/Expedition/ZaryaAssault.yml
+++ b/Resources/Maps/Corvax/Shuttles/Expedition/ZaryaAssault.yml
@@ -6243,7 +6243,7 @@ entities:
       pos: -3.5,-8.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -21302.393
+      secondsUntilStateChange: -21386.908
       state: Closing
   - uid: 749
     components:
@@ -6264,7 +6264,7 @@ entities:
       pos: 4.5,-6.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -22804.4
+      secondsUntilStateChange: -22888.916
       state: Closing
   - uid: 752
     components:
@@ -9821,6 +9821,23 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -5.5,-15.5
       parent: 2
+- proto: SpawnPointContractor
+  entities:
+  - uid: 1795
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 2
+  - uid: 1796
+    components:
+    - type: Transform
+      pos: -7.5,-0.5
+      parent: 2
+  - uid: 1797
+    components:
+    - type: Transform
+      pos: 9.5,-0.5
+      parent: 2
 - proto: SpawnPointLatejoin
   entities:
   - uid: 1153
@@ -9842,6 +9859,45 @@ entities:
     components:
     - type: Transform
       pos: -1.5,-7.5
+      parent: 2
+- proto: SpawnPointMercenary
+  entities:
+  - uid: 1789
+    components:
+    - type: Transform
+      pos: -9.5,-6.5
+      parent: 2
+  - uid: 1790
+    components:
+    - type: Transform
+      pos: 11.5,-6.5
+      parent: 2
+  - uid: 1791
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 2
+  - uid: 1792
+    components:
+    - type: Transform
+      pos: 2.5,-6.5
+      parent: 2
+  - uid: 1793
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 2
+  - uid: 1794
+    components:
+    - type: Transform
+      pos: -8.5,5.5
+      parent: 2
+- proto: SpawnPointPilot
+  entities:
+  - uid: 1788
+    components:
+    - type: Transform
+      pos: 0.5,4.5
       parent: 2
 - proto: SpiderWeb
   entities:

--- a/Resources/Maps/Corvax/Shuttles/Expedition/ZaryaAssault.yml
+++ b/Resources/Maps/Corvax/Shuttles/Expedition/ZaryaAssault.yml
@@ -1,0 +1,12776 @@
+meta:
+  format: 6
+  postmapinit: false
+tilemap:
+  0: Space
+  7: FloorAsteroidSandRed
+  11: FloorConcreteMono
+  3: FloorDark
+  6: FloorDarkPlastic
+  4: FloorElevatorShaft
+  69: FloorMetalDiamond
+  9: FloorOldConcrete
+  8: FloorOldConcreteMono
+  83: FloorReinforced
+  10: FloorShuttleBlack
+  97: FloorSteel
+  104: FloorSteelDirty
+  5: FloorTechMaint
+  129: Lattice
+  130: Plating
+  1: PlatingBurnt
+  2: PlatingDamaged
+entities:
+- proto: ""
+  entities:
+  - uid: 2
+    components:
+    - type: MetaData
+      name: Заря
+    - type: Transform
+      pos: -0.53125,-0.5
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: CQAAAAAACQAAAAAACQAAAAAABAAAAAAAgQAAAAAAgQAAAAAABAAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAACQAAAAAACQAAAAAACQAAAAAAggAAAAAAAAAAAAAAgQAAAAAAggAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAABAAAAAAACQAAAAAABAAAAAAAAAAAAAAACQAAAAAACQAAAAAAggAAAAAAggAAAAAAAAAAAAAAgQAAAAAAggAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAACQAAAAAACQAAAAAAggAAAAAAgQAAAAAAAAAAAAAAgQAAAAAAggAAAAAAggAAAAAAAwAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAACQAAAAAACQAAAAAAggAAAAAAgQAAAAAAAAAAAAAAgQAAAAAAggAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAggAAAAAAgQAAAAAAAAAAAAAACQAAAAAACQAAAAAAggAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAggAAAAAAAAAAAAAAAAAAAAAABAAAAAAABAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAggAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAggAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAggAAAAAAggAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAggAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAABAAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAggAAAAAACQAAAAAACQAAAAAACQAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        0,-1:
+          ind: 0,-1
+          tiles: BAAAAAAABAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAABQAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAABgAAAAAABgAAAAAAAwAAAAAAggAAAAAAggAAAAAAggAAAAAABQAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAABgAAAAAABgAAAAAAAwAAAAAAggAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAABgAAAAAABgAAAAAAAwAAAAAAggAAAAAAggAAAAAAggAAAAAABQAAAAAAggAAAAAAggAAAAAAggAAAAAABQAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAABAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAABQAAAAAAggAAAAAAggAAAAAAggAAAAAABQAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAggAAAAAAggAAAAAABQAAAAAAggAAAAAAggAAAAAAggAAAAAABQAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAABQAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAggAAAAAAggAAAAAABAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAggAAAAAAggAAAAAARQAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAACQAAAAAACQAAAAAACQAAAAAAggAAAAAAggAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAABAAAAAAARQAAAAAARQAAAAAARQAAAAAAggAAAAAAAAAAAAAAAAAAAAAACQAAAAAACQAAAAAAggAAAAAAgQAAAAAAgQAAAAAAggAAAAAACQAAAAAACQAAAAAACQAAAAAABAAAAAAARQAAAAAARQAAAAAARQAAAAAAggAAAAAAgQAAAAAAAAAAAAAACQAAAAAACQAAAAAAggAAAAAAgQAAAAAAgQAAAAAAggAAAAAAggAAAAAAggAAAAAAAwAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAACQAAAAAACQAAAAAAggAAAAAAggAAAAAAgQAAAAAAgQAAAAAAggAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAACQAAAAAACQAAAAAACQAAAAAAggAAAAAAgQAAAAAAgQAAAAAAggAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAABAAAAAAACQAAAAAABAAAAAAAAAAAAAAA
+          version: 6
+        -1,0:
+          ind: -1,0
+          tiles: AAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAABAAAAAAAgQAAAAAAgQAAAAAABAAAAAAACQAAAAAACQAAAAAAAAAAAAAAAAAAAAAABAAAAAAACgAAAAAABAAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAggAAAAAAgQAAAAAAAAAAAAAAggAAAAAACQAAAAAACQAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAggAAAAAAgQAAAAAAAAAAAAAAggAAAAAAggAAAAAACQAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAABAAAAAAAggAAAAAAggAAAAAAgQAAAAAAAAAAAAAAgQAAAAAAggAAAAAACQAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAAggAAAAAAgQAAAAAAAAAAAAAAgQAAAAAAggAAAAAACQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAggAAAAAACQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAAgAAAAABCAAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAAggAAAAAAAAAAAAAAAAAAAAAAgQAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAAggAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAAggAAAAAAggAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAAggAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAABAAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAACAAAAAAACAAAAAAACAAAAAAAggAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAA
+          version: 6
+        -1,-1:
+          ind: -1,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAAggAAAAAAggAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAAggAAAAAAAwAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAAggAAAAAAAwAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAAggAAAAAAAwAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACAAAAAAAggAAAAAAggAAAAAAggAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAAggAAAAAAggAAAAAACQAAAAAACQAAAAAACQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAACwAAAAAACwAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAABAAAAAAAggAAAAAAggAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAARQAAAAAAggAAAAAAggAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAARQAAAAAARQAAAAAARQAAAAAABAAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAggAAAAAAggAAAAAACQAAAAAACQAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAARQAAAAAARQAAAAAARQAAAAAABAAAAAAACQAAAAAACQAAAAAACQAAAAAAggAAAAAAgQAAAAAAgQAAAAAAggAAAAAACQAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAwAAAAAAggAAAAAAggAAAAAAggAAAAAAgQAAAAAAgQAAAAAAggAAAAAACQAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAggAAAAAAgQAAAAAAgQAAAAAAggAAAAAAggAAAAAACQAAAAAAAAAAAAAAAAAAAAAABAAAAAAACgAAAAAABAAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAggAAAAAAgQAAAAAAgQAAAAAAggAAAAAACQAAAAAACQAAAAAA
+          version: 6
+        -1,-2:
+          ind: -1,-2
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAAggAAAAAAggAAAAAAgQAAAAAAgQAAAAAA
+          version: 6
+        0,-2:
+          ind: 0,-2
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAggAAAAAAggAAAAAAggAAAAAABQAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        0,1:
+          ind: 0,1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        -1,1:
+          ind: -1,1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: Basalt5
+          decals:
+            299: -9.994183,9.793764
+        - node:
+            color: '#D4D4D4FF'
+            id: BoxGreyscale
+          decals:
+            179: 9,-2
+            180: -9,-2
+        - node:
+            angle: -1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: BoxGreyscale
+          decals:
+            124: -1,-15
+            125: -1,-13
+            126: 1,-13
+            127: 1,-15
+        - node:
+            color: '#5E7C1696'
+            id: BrickCornerOverlayNE
+          decals:
+            188: 10,10
+            189: 9,11
+            190: 12,5
+        - node:
+            color: '#2A4229FF'
+            id: BrickCornerOverlayNW
+          decals:
+            280: -12,5
+            281: -10,10
+            282: -9,11
+        - node:
+            color: '#8CB7E8FF'
+            id: BrickCornerOverlayNW
+          decals:
+            134: -11,-14
+        - node:
+            color: '#2A4229FF'
+            id: BrickCornerOverlaySE
+          decals:
+            277: -6,6
+            278: -7,4
+        - node:
+            color: '#5E7C1696'
+            id: BrickCornerOverlaySE
+          decals:
+            191: 12,4
+        - node:
+            color: '#2A4229FF'
+            id: BrickCornerOverlaySW
+          decals:
+            279: -12,4
+        - node:
+            color: '#5E7C1696'
+            id: BrickCornerOverlaySW
+          decals:
+            192: 6,6
+            193: 7,4
+        - node:
+            color: '#8CB7E8FF'
+            id: BrickCornerOverlaySW
+          decals:
+            160: -11,-17
+        - node:
+            color: '#2A4229FF'
+            id: BrickLineOverlayE
+          decals:
+            274: -6,9
+            275: -6,8
+            276: -6,7
+            283: -7,5
+        - node:
+            color: '#5E7C1696'
+            id: BrickLineOverlayE
+          decals:
+            184: 10,9
+            185: 10,10
+            186: 11,7
+            187: 11,6
+        - node:
+            color: '#8CB7E8FF'
+            id: BrickLineOverlayE
+          decals:
+            139: -8,-14
+            140: -8,-17
+            141: -5,-17
+            142: -4,-16
+            143: -4,-15
+            144: -4,-14
+            145: -4,-13
+            146: -5,-12
+            147: -6,-11
+            148: -9,-10
+        - node:
+            color: '#2A4229FF'
+            id: BrickLineOverlayN
+          decals:
+            267: -6,12
+            268: -8,11
+        - node:
+            color: '#5E7C1696'
+            id: BrickLineOverlayN
+          decals:
+            199: 8,11
+            200: 6,12
+        - node:
+            color: '#8CB7E8FF'
+            id: BrickLineOverlayN
+          decals:
+            137: -9,-14
+            138: -8,-14
+            149: -8,-11
+            150: -6,-11
+            151: -7,-11
+            152: -5,-12
+            153: -4,-13
+            154: -9,-10
+        - node:
+            color: '#2A4229FF'
+            id: BrickLineOverlayS
+          decals:
+            269: -11,4
+            270: -10,4
+            271: -9,4
+        - node:
+            color: '#5E7C1696'
+            id: BrickLineOverlayS
+          decals:
+            196: 9,4
+            197: 10,4
+            198: 11,4
+        - node:
+            color: '#8CB7E8FF'
+            id: BrickLineOverlayS
+          decals:
+            161: -10,-17
+            162: -9,-17
+            163: -8,-17
+            164: -7,-17
+            165: -6,-17
+            166: -5,-17
+            167: -4,-16
+        - node:
+            color: '#2A4229FF'
+            id: BrickLineOverlayW
+          decals:
+            272: -11,7
+            273: -10,9
+            294: -11,6
+        - node:
+            color: '#5E7C1696'
+            id: BrickLineOverlayW
+          decals:
+            194: 6,9
+            195: 7,5
+            218: 6,8
+            219: 6,7
+        - node:
+            color: '#8CB7E8FF'
+            id: BrickLineOverlayW
+          decals:
+            135: -11,-15
+            136: -11,-16
+            155: -10,-10
+            156: -10,-11
+            157: -10,-12
+            158: -10,-13
+            159: -11,-16
+        - node:
+            color: '#4979AFFF'
+            id: BrickTileWhiteCornerNe
+          decals:
+            35: 1,5
+        - node:
+            color: '#EDB142FF'
+            id: BrickTileWhiteCornerNe
+          decals:
+            55: 11,-14
+        - node:
+            color: '#4979AFFF'
+            id: BrickTileWhiteCornerNw
+          decals:
+            36: -1,5
+        - node:
+            color: '#EDB142FF'
+            id: BrickTileWhiteCornerNw
+          decals:
+            48: 9,-10
+            49: 6,-11
+            50: 5,-12
+            51: 4,-13
+        - node:
+            color: '#EDB142FF'
+            id: BrickTileWhiteCornerSe
+          decals:
+            54: 11,-17
+        - node:
+            color: '#EDB142FF'
+            id: BrickTileWhiteCornerSw
+          decals:
+            52: 4,-16
+            53: 5,-17
+        - node:
+            color: '#4979AFFF'
+            id: BrickTileWhiteInnerNe
+          decals:
+            34: 1,1
+            38: 2,0
+        - node:
+            color: '#EDB142FF'
+            id: BrickTileWhiteInnerNe
+          decals:
+            61: 10,-14
+        - node:
+            color: '#4979AFFF'
+            id: BrickTileWhiteInnerNw
+          decals:
+            33: -1,1
+            37: -2,0
+        - node:
+            color: '#EDB142FF'
+            id: BrickTileWhiteInnerNw
+          decals:
+            56: 10,-10
+            73: 5,-13
+            74: 6,-12
+            75: 9,-11
+        - node:
+            color: '#4979AFFF'
+            id: BrickTileWhiteInnerSe
+          decals:
+            31: 1,-1
+            39: 2,0
+        - node:
+            color: '#4979AFFF'
+            id: BrickTileWhiteInnerSw
+          decals:
+            32: -1,-1
+            40: -2,0
+        - node:
+            color: '#4979AFFF'
+            id: BrickTileWhiteLineE
+          decals:
+            26: 1,4
+            27: 1,3
+            28: 1,2
+            29: 1,-2
+        - node:
+            color: '#EDB142FF'
+            id: BrickTileWhiteLineE
+          decals:
+            57: 10,-10
+            58: 10,-11
+            59: 10,-12
+            60: 10,-13
+            62: 11,-15
+            63: 11,-16
+        - node:
+            color: '#4979AFFF'
+            id: BrickTileWhiteLineN
+          decals:
+            25: 0,5
+        - node:
+            color: '#EDB142FF'
+            id: BrickTileWhiteLineN
+          decals:
+            71: 7,-11
+            72: 8,-11
+        - node:
+            color: '#EDB142FF'
+            id: BrickTileWhiteLineS
+          decals:
+            64: 10,-17
+            65: 9,-17
+            66: 8,-17
+            67: 7,-17
+            68: 6,-17
+        - node:
+            color: '#4979AFFF'
+            id: BrickTileWhiteLineW
+          decals:
+            22: -1,3
+            23: -1,2
+            24: -1,4
+            30: -1,-2
+        - node:
+            color: '#EDB142FF'
+            id: BrickTileWhiteLineW
+          decals:
+            69: 4,-15
+            70: 4,-14
+        - node:
+            angle: -1.5707963267948966 rad
+            color: '#EDB142FF'
+            id: Caution
+          decals:
+            119: 11,1
+            120: 11,-1
+        - node:
+            angle: 1.5707963267948966 rad
+            color: '#EDB142FF'
+            id: Caution
+          decals:
+            121: -11,-1
+            122: -11,1
+        - node:
+            angle: 3.141592653589793 rad
+            color: '#FFBB84FF'
+            id: Caution
+          decals:
+            128: 0,-15
+        - node:
+            color: '#5E7C1696'
+            id: CheckerNESW
+          decals:
+            220: 6,7
+            221: 7,8
+            222: 6,8
+            223: 6,9
+            224: 7,9
+            225: 7,10
+            226: 6,10
+            227: 5,10
+            228: 5,11
+            229: 6,11
+            230: 7,11
+            231: 6,12
+            232: 5,12
+            233: 7,12
+            234: 8,11
+            235: 9,11
+            236: 9,10
+            237: 8,10
+            238: 8,9
+            239: 9,9
+            240: 10,10
+            241: 10,9
+            242: 8,8
+            243: 9,8
+            244: 10,8
+            245: 10,7
+            246: 11,7
+            247: 11,6
+            248: 10,6
+            249: 8,6
+            250: 9,6
+            251: 9,7
+            252: 8,7
+            253: 7,6
+            254: 7,7
+            255: 7,5
+            256: 8,5
+            257: 8,4
+            258: 7,4
+            259: 9,5
+            260: 9,4
+            261: 10,4
+            262: 10,5
+            263: 11,5
+            264: 11,4
+            265: 12,4
+            266: 12,5
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: Damaged
+          decals:
+            300: -7,10
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: Dirt
+          decals:
+            335: -10,10
+            336: -7,10
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: DirtHeavyMonotile
+          decals:
+            301: -11,6
+            302: -10,5
+            303: -10,5
+            304: -9,4
+            305: -8,6
+            306: -9,6
+            307: -8,7
+            308: -9,8
+            309: -9,9
+            310: -8,9
+            311: -8,11
+            312: -7,8
+            313: -7,8
+            314: -7,8
+            315: -6,10
+            316: -7,11
+            317: -5,11
+            338: -12,-4
+            339: -12,-4
+            340: -10,-4
+            341: -10,-8
+            342: -11,-7
+            343: -7,-7
+            344: -7,-6
+            345: -6,-7
+            346: -2,-8
+            347: -2,-7
+            348: -2,-7
+            349: 2,-5
+            350: 3,-6
+            351: 3,-7
+            352: 3,-8
+            353: 1,-10
+            354: -1,-10
+            355: -2,-10
+            356: 2,-8
+            357: 2,-6
+            358: 0,-5
+            359: 0,-6
+            360: 2,-8
+            361: 2,-10
+            362: 1,-1
+            363: 1,-2
+            364: -1,-1
+            365: -2,0
+            366: 0,0
+            367: 2,0
+            368: 0,2
+            369: 0,3
+            370: 0,4
+            371: 0,4
+            372: 0,1
+            373: -1,1
+            374: 0,4
+            375: 1,4
+            376: -7,-2
+            377: -7,-2
+            378: -7,0
+            379: -10,2
+            380: -11,2
+            381: -9,0
+            382: -10,-1
+            383: 7,-2
+            384: 8,-1
+            385: 8,0
+            386: 7,2
+            387: 8,2
+            388: 10,-2
+            389: 8,-2
+            390: 9,-1
+            391: 10,0
+            392: 10,1
+            393: 11,2
+            394: 11,-1
+            395: 11,-2
+            396: 11,5
+            397: 9,4
+            398: 7,6
+            399: 7,6
+            400: 8,5
+            401: 9,5
+            402: 9,6
+            403: 8,8
+            404: 6,10
+            405: 6,11
+            406: 6,11
+            407: 6,10
+            408: 7,10
+            409: 8,9
+            410: 10,8
+            411: 9,9
+            412: 9,9
+            413: 9,9
+            414: 9,9
+            415: 9,8
+            416: 10,7
+            417: 11,5
+            418: 11,5
+            419: 8,7
+            420: 7,7
+            421: 7,8
+            422: 7,9
+            423: 7,8
+            424: 11,-7
+            425: 10,-8
+            426: 8,-8
+            427: 8,-7
+            428: 7,-6
+            429: 6,-6
+            430: 5,-8
+            431: 5,-9
+            432: 6,-8
+            433: 6,-8
+            434: 7,-7
+            435: 7,-5
+            436: 8,-5
+            437: 8,-5
+            438: 7,-5
+            439: 6,-7
+            440: 4,-8
+            441: 3,-9
+            442: 3,-8
+            443: 2,-7
+            444: 0,-6
+            445: 1,-6
+            446: 1,-10
+            447: 0,-11
+            448: -1,-11
+            449: 0,-14
+            450: -1,-14
+            451: 0,-13
+            452: 1,-13
+            453: -6,-14
+            454: -6,-15
+            455: -7,-16
+            456: -9,-16
+            457: -9,-15
+            458: -9,-15
+            459: -11,-16
+            460: -8,-16
+            461: -9,-15
+            462: -9,-14
+            463: -9,-13
+            464: -9,-11
+            465: -7,-12
+            466: -7,-14
+            467: -4,-15
+            468: -4,-15
+            469: -5,-13
+            470: -6,-12
+            471: -8,-13
+            472: -8,-16
+            473: -6,-16
+            474: -5,-17
+            475: -10,-13
+            476: -9,-13
+            477: -9,-12
+            478: -7,-13
+            479: -7,-14
+            480: -6,-15
+            481: -6,-16
+            482: -8,-16
+            483: -6,-14
+            593: -11,-5
+            594: -11,-5
+            595: -12,-5
+            596: -12,-5
+            597: -11,-4
+            598: -11,-4
+            599: -10,-5
+            600: -10,-5
+            601: -10,-4
+            602: 11,-5
+            603: 11,-5
+            604: 10,-5
+            605: 10,-5
+            606: 10,-4
+            607: 12,-5
+            608: 12,-5
+            609: 12,-4
+            610: 11,-4
+            611: 11,-4
+            612: 11,-5
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: DirtLight
+          decals:
+            318: -10,6
+            319: -9,8
+            320: -7,6
+            321: -7,5
+            322: -8,4
+            323: -11,5
+            324: -9,1
+            325: -9,1
+            326: -8,-1
+            327: -9,-1
+            328: -10,-1
+            329: -10,-1
+            330: -8,-5
+            331: -8,-6
+            332: -6,-7
+            333: -6,-7
+            334: -8,-7
+            493: -9,-16
+            494: -9,-16
+            495: -10,-16
+            496: -7,-12
+            497: -6,-7
+            498: -6,-8
+            499: -7,-8
+            500: -6,-9
+            501: -10,-7
+            502: -10,-7
+            503: -8,-7
+            504: -2,-7
+            505: -1,-6
+            506: -2,-7
+            507: -2,-8
+            508: 0,-10
+            509: 0,-10
+            510: 2,-10
+            511: 2,-10
+            512: 3,-9
+            513: 2,-11
+            514: 0,-10
+            515: -1,-8
+            516: 0,-6
+            517: 0,-5
+            518: 0,-3
+            519: 0,-1
+            520: -1,-1
+            521: -1,1
+            522: 1,1
+            523: 1,0
+            524: 0,1
+            525: 0,3
+            526: 0,4
+            527: 0,2
+            528: 0,0
+            529: 0,-1
+            530: 0,-2
+            531: 1,-2
+            532: 0,-1
+            533: -2,1
+            534: 7,-8
+            535: 7,-8
+            536: 10,-7
+            537: 11,-8
+            538: 11,-8
+            539: 10,-8
+            540: 8,-2
+            541: 8,-1
+            542: 7,0
+            543: 10,1
+            544: 11,1
+            545: 9,5
+            546: 9,5
+            547: 7,6
+            548: 7,7
+            549: 7,10
+            550: 6,12
+            551: 6,12
+            552: 8,9
+            553: -7,11
+            554: -11,-1
+            555: -10,-2
+            556: -8,-1
+            557: -8,1
+            558: -8,1
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: DirtMedium
+          decals:
+            484: -6,-14
+            485: -7,-13
+            486: -10,-11
+            487: -10,-11
+            488: -5,-16
+            489: -10,-15
+            490: -10,-15
+            491: -5,-13
+            492: -5,-13
+            559: -6,-7
+            560: -6,-4
+            561: -6,-4
+            562: -8,-4
+            563: -2,-8
+            564: -2,-9
+            565: -2,-11
+            566: 2,-9
+            567: 2,-9
+            568: 6,-9
+            569: 8,-8
+            570: 10,-8
+            571: 11,-7
+            572: 10,-7
+            573: 11,-5
+            574: 10,-5
+            575: 10,-4
+            576: 9,-1
+            577: 9,-2
+            578: 8,1
+            579: 10,6
+            580: 2,0
+            581: 0,2
+            582: -1,3
+            583: -1,4
+            584: 0,4
+            585: 0,4
+            586: 0,2
+            587: -1,1
+            588: -2,0
+            589: -2,0
+        - node:
+            color: '#2A4229FF'
+            id: HalfTileOverlayGreyscale
+          decals:
+            181: -8,2
+            182: -7,2
+            183: -9,2
+        - node:
+            color: '#315074FF'
+            id: HalfTileOverlayGreyscale
+          decals:
+            45: 0,-5
+            46: 1,-5
+            47: 2,-5
+        - node:
+            color: '#334D6BFF'
+            id: HalfTileOverlayGreyscale
+          decals:
+            105: -1,-5
+            106: -2,-5
+        - node:
+            color: '#5E7C1696'
+            id: HalfTileOverlayGreyscale
+          decals:
+            215: 7,2
+            216: 8,2
+            217: 9,2
+        - node:
+            color: '#52B4E996'
+            id: HalfTileOverlayGreyscale180
+          decals:
+            613: -11,-8
+            614: -10,-8
+            615: -9,-8
+            616: -8,-8
+        - node:
+            color: '#771300FF'
+            id: HalfTileOverlayGreyscale180
+          decals:
+            100: -3,-11
+            101: -2,-11
+            102: 2,-11
+            103: 3,-11
+            109: -2,-5
+            110: 2,-5
+        - node:
+            color: '#9C752BFF'
+            id: HalfTileOverlayGreyscale180
+          decals:
+            76: 11,-8
+            77: 10,-8
+            78: 9,-8
+            79: 8,-8
+        - node:
+            color: '#771300FF'
+            id: HalfTileOverlayGreyscale270
+          decals:
+            99: -3,-11
+            107: -3,-10
+            111: -3,-6
+        - node:
+            color: '#771300FF'
+            id: HalfTileOverlayGreyscale90
+          decals:
+            104: 3,-11
+            108: 3,-10
+            112: 3,-6
+        - node:
+            color: '#2A4229FF'
+            id: MiniTileInnerOverlayNE
+          decals:
+            286: -5,11
+        - node:
+            color: '#5E7C1696'
+            id: MiniTileInnerOverlayNE
+          decals:
+            201: 9,10
+            202: 11,5
+            203: 10,8
+            206: 7,11
+        - node:
+            color: '#8CB7E8FF'
+            id: MiniTileInnerOverlayNE
+          decals:
+            168: -9,-11
+            169: -6,-12
+            170: -5,-13
+            171: -10,-14
+            172: -8,-15
+            176: -10,-10
+        - node:
+            color: '#2A4229FF'
+            id: MiniTileInnerOverlayNW
+          decals:
+            285: -11,5
+            288: -10,8
+            289: -9,10
+            290: -7,11
+        - node:
+            color: '#5E7C1696'
+            id: MiniTileInnerOverlayNW
+          decals:
+            204: 5,11
+        - node:
+            color: '#8CB7E8FF'
+            id: MiniTileInnerOverlayNW
+          decals:
+            173: -10,-14
+        - node:
+            color: '#2A4229FF'
+            id: MiniTileInnerOverlaySE
+          decals:
+            284: -7,6
+            287: -5,11
+            291: -6,10
+            292: -8,4
+        - node:
+            color: '#5E7C1696'
+            id: MiniTileInnerOverlaySE
+          decals:
+            205: 8,4
+        - node:
+            color: '#8CB7E8FF'
+            id: MiniTileInnerOverlaySE
+          decals:
+            174: -5,-16
+            175: -8,-16
+        - node:
+            color: '#2A4229FF'
+            id: MiniTileInnerOverlaySW
+          decals:
+            293: -8,4
+        - node:
+            color: '#5E7C1696'
+            id: MiniTileInnerOverlaySW
+          decals:
+            207: 5,11
+            208: 8,4
+            209: 7,6
+            210: 6,10
+        - node:
+            color: '#002F66FF'
+            id: North
+          decals:
+            129: 0,3
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: Rust
+          decals:
+            337: -11,-4
+            590: -11,-5
+            591: -10,-5
+            592: -11,-5
+        - node:
+            color: '#EDB142FF'
+            id: WarnBoxGreyscale
+          decals:
+            84: -2,-13
+            85: -2,-14
+            86: -2,-15
+            87: 2,-13
+            88: 2,-14
+            89: 2,-15
+            113: -11,-2
+            114: -11,2
+            115: -10,-2
+            116: -10,2
+            117: 11,-2
+            118: 10,-2
+        - node:
+            color: '#EFB341FF'
+            id: WarnBoxGreyscale
+          decals:
+            177: 10,2
+            178: 11,2
+        - node:
+            color: '#9B9B9BFF'
+            id: WarnFull
+          decals:
+            80: -13,1
+            81: -13,-1
+            82: 13,1
+            83: 13,-1
+        - node:
+            color: '#2A4229FF'
+            id: minitile_diagonal
+          decals:
+            295: -11,8
+            296: -7,12
+        - node:
+            color: '#5E7C1696'
+            id: minitile_diagonal
+          decals:
+            212: 5,12
+        - node:
+            color: '#2A4229FF'
+            id: minitile_diagonal180
+          decals:
+            298: -5,10
+        - node:
+            color: '#5E7C1696'
+            id: minitile_diagonal270
+          decals:
+            214: 5,10
+        - node:
+            color: '#2A4229FF'
+            id: minitile_diagonal90
+          decals:
+            297: -5,12
+        - node:
+            color: '#5E7C1696'
+            id: minitile_diagonal90
+          decals:
+            211: 11,8
+            213: 7,12
+        - node:
+            cleanable: True
+            angle: -0.8726646259971648 rad
+            color: '#4A2A00FF'
+            id: pawprint
+          decals:
+            21: 11.205413,-5.375915
+        - node:
+            cleanable: True
+            angle: -0.17453292519943295 rad
+            color: '#4A2A00FF'
+            id: pawprint
+          decals:
+            20: 10.802635,-6.0898814
+        - node:
+            cleanable: True
+            angle: 1.0471975511965976 rad
+            color: '#4A2A00FF'
+            id: shortline
+          decals:
+            19: 9.767913,-5.2930665
+        - node:
+            cleanable: True
+            angle: 1.5707963267948966 rad
+            color: '#4A2A00FF'
+            id: shortline
+          decals:
+            18: 11.156801,-3.6472335
+        - node:
+            color: '#3F000084'
+            id: splatter
+          decals:
+            0: -12.258271,-3.731119
+            1: -12.355494,-5.383897
+            2: -12.265216,-3.953341
+            3: -11.654105,-3.6338968
+            4: -9.508271,-4.870008
+        - node:
+            cleanable: True
+            color: '#4A2A00FF'
+            id: splatter
+          decals:
+            12: 11.885515,-4.1693344
+            13: 11.843849,-5.1485014
+            14: 11.836905,-4.84989
+            15: 12.32996,-5.4193344
+            16: 12.323015,-4.7179456
+            17: 11.941071,-3.7735014
+        - node:
+            cleanable: True
+            color: '#56FF008C'
+            id: splatter
+          decals:
+            96: 1.3749907,-8.943432
+            97: 0.6666572,-7.568432
+            98: -2.0625095,-8.499833
+        - node:
+            color: '#8C000084'
+            id: splatter
+          decals:
+            5: -12.558049,-3.5892582
+            6: -12.5719385,-5.554536
+            7: -9.8844385,-3.380925
+        - node:
+            cleanable: True
+            color: '#C9C9C9FF'
+            id: splatter
+          decals:
+            123: 10.996604,-3.4656546
+        - node:
+            cleanable: True
+            color: '#E591006F'
+            id: splatter
+          decals:
+            8: 10.191071,-3.684801
+            9: 9.677182,-3.6778564
+            10: 9.670238,-4.1014676
+            11: 9.732738,-3.63619
+        - node:
+            cleanable: True
+            color: '#F9FF008C'
+            id: splatter
+          decals:
+            93: -1.3341715,-7.849682
+            94: 1.1936107,-9.662182
+            95: 2.0894442,-8.349682
+        - node:
+            cleanable: True
+            color: '#FFA1008C'
+            id: splatter
+          decals:
+            90: -1.2768735,-9.484165
+            91: -0.7977067,-9.494581
+            92: -1.0581235,-9.869581
+        - node:
+            cleanable: True
+            color: '#FFFFFF3E'
+            id: splatter
+          decals:
+            130: -0.041734815,-6.6260896
+            131: 0.94784844,-6.3309507
+            132: 1.2256262,-6.574006
+            133: 0.722154,-9.716367
+        - node:
+            color: '#315074FF'
+            id: tile_diagonal
+          decals:
+            41: -2,-1
+            42: 2,1
+        - node:
+            color: '#315074FF'
+            id: tile_diagonal_flipped
+          decals:
+            43: -2,1
+            44: 2,-1
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          0,0:
+            0: 13183
+            1: 32768
+          0,-1:
+            0: 29491
+            1: 136
+          -1,0:
+            0: 35022
+            1: 8193
+          0,1:
+            0: 51
+            1: 29704
+          -1,1:
+            0: 136
+            1: 50178
+          0,2:
+            1: 51217
+            2: 13056
+          -1,2:
+            2: 34816
+            1: 25089
+          0,3:
+            2: 3
+            1: 8
+          -1,3:
+            2: 8
+            1: 258
+          1,0:
+            1: 8739
+            0: 2188
+          1,2:
+            1: 1
+            0: 61128
+            3: 4
+          1,3:
+            0: 14
+            1: 2304
+          1,-1:
+            1: 8977
+            0: 34828
+          1,1:
+            1: 2
+            4: 1024
+            3: 16384
+            0: 34952
+          2,0:
+            0: 7167
+            3: 1024
+          2,1:
+            0: 49151
+            3: 16384
+          2,2:
+            0: 13119
+            5: 64
+            6: 1024
+          2,-1:
+            0: 64285
+            7: 1024
+          2,3:
+            1: 32
+          3,0:
+            0: 112
+          3,1:
+            0: 17
+            1: 4
+          3,2:
+            1: 274
+          3,3:
+            1: 1
+          3,-1:
+            0: 28673
+            1: 4
+          0,-4:
+            0: 30576
+          0,-5:
+            1: 30720
+          -1,-4:
+            0: 56785
+          0,-3:
+            0: 65523
+          -1,-3:
+            0: 65512
+          0,-2:
+            0: 32767
+          -1,-2:
+            0: 53247
+          -1,-1:
+            0: 51336
+            1: 307
+          1,-4:
+            0: 65535
+          1,-3:
+            0: 61902
+          1,-2:
+            0: 61439
+          1,-5:
+            0: 57344
+            1: 64
+          2,-4:
+            0: 32767
+          2,-3:
+            0: 18039
+          2,-2:
+            0: 55807
+          2,-5:
+            0: 61440
+            1: 112
+          3,-3:
+            1: 257
+          3,-2:
+            0: 4096
+            1: 32
+          3,-4:
+            1: 546
+          3,-5:
+            1: 8208
+          -4,0:
+            0: 192
+          -4,-1:
+            0: 49152
+            1: 4
+          -4,1:
+            1: 4
+          -3,0:
+            0: 3838
+          -3,1:
+            0: 61183
+          -4,2:
+            1: 8
+          -3,-1:
+            0: 65031
+          -3,2:
+            1: 272
+            0: 36046
+          -3,3:
+            1: 129
+          -2,0:
+            0: 4919
+            1: 34952
+          -2,1:
+            0: 30515
+            1: 8
+          -2,2:
+            0: 65399
+          -2,-1:
+            0: 13079
+            1: 34816
+          -2,3:
+            0: 14
+            1: 512
+          -4,-4:
+            1: 2184
+          -4,-5:
+            1: 32768
+          -4,-2:
+            1: 128
+          -3,-2:
+            0: 29422
+          -3,-4:
+            0: 52462
+            3: 512
+          -3,-3:
+            1: 257
+            0: 19660
+          -3,-5:
+            3: 8192
+            0: 49152
+            1: 208
+          -2,-4:
+            0: 65535
+          -2,-3:
+            0: 57471
+          -2,-2:
+            0: 65535
+          -2,-5:
+            0: 61440
+            1: 80
+          -1,-5:
+            1: 49664
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          immutable: True
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.14996
+          moles:
+          - 20.078888
+          - 75.53487
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.14984
+          moles:
+          - 20.078888
+          - 75.53487
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 23.291512
+          - 87.62045
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.1499
+          moles:
+          - 20.078888
+          - 75.53487
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.1499
+          moles:
+          - 18.472576
+          - 69.49208
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: NavMap
+    - type: BecomesStation
+      id: ZaryaА
+- proto: AirAlarm
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-2.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 946
+      - 971
+      - 37
+      - 964
+      - 953
+      - 41
+      - 965
+      - 954
+      - 45
+  - uid: 5
+    components:
+    - type: Transform
+      pos: 7.5,-9.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 961
+      - 950
+      - 43
+      - 42
+      - 952
+      - 963
+      - 959
+      - 44
+      - 970
+  - uid: 6
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-9.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 38
+      - 973
+      - 947
+      - 40
+      - 949
+      - 960
+  - uid: 7
+    components:
+    - type: Transform
+      pos: -8.5,-5.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 960
+      - 40
+      - 949
+      - 39
+      - 951
+      - 962
+      - 953
+      - 41
+      - 964
+      - 963
+      - 42
+      - 952
+      - 954
+      - 965
+      - 45
+  - uid: 8
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,6.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 957
+      - 49
+      - 966
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 11.5,3.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 968
+      - 48
+      - 955
+  - uid: 10
+    components:
+    - type: Transform
+      pos: -10.5,3.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 47
+      - 956
+      - 969
+  - uid: 11
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,6.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 958
+      - 967
+      - 46
+- proto: AirCanister
+  entities:
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 4.5,-13.5
+      parent: 2
+  - uid: 13
+    components:
+    - type: Transform
+      pos: 4.5,-12.5
+      parent: 2
+- proto: AirlockEngineeringGlass
+  entities:
+  - uid: 14
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,-8.5
+      parent: 2
+- proto: AirlockExternalGlass
+  entities:
+  - uid: 15
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -11.5,1.5
+      parent: 2
+  - uid: 16
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -11.5,-0.5
+      parent: 2
+  - uid: 17
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-0.5
+      parent: 2
+  - uid: 18
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,1.5
+      parent: 2
+  - uid: 19
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,0.5
+      parent: 2
+  - uid: 20
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,0.5
+      parent: 2
+  - uid: 21
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,0.5
+      parent: 2
+  - uid: 22
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,0.5
+      parent: 2
+  - uid: 23
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-11.5
+      parent: 2
+  - uid: 24
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-11.5
+      parent: 2
+  - uid: 25
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-11.5
+      parent: 2
+- proto: AirlockGlass
+  entities:
+  - uid: 26
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-5.5
+      parent: 2
+  - uid: 27
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-2.5
+      parent: 2
+  - uid: 28
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-2.5
+      parent: 2
+- proto: AirlockGlassShuttle
+  entities:
+  - uid: 29
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -13.5,1.5
+      parent: 2
+  - uid: 30
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -13.5,-0.5
+      parent: 2
+  - uid: 31
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,1.5
+      parent: 2
+  - uid: 32
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,-0.5
+      parent: 2
+- proto: AirlockMedical
+  entities:
+  - uid: 33
+    components:
+    - type: Transform
+      pos: -9.5,-8.5
+      parent: 2
+- proto: AirlockMercenaryGlassLocked
+  entities:
+  - uid: 35
+    components:
+    - type: Transform
+      pos: -10.5,-5.5
+      parent: 2
+    - type: AccessReader
+      access:
+      - - Captain
+      - - Command
+      - - Mercenary
+- proto: AirlockMercenaryLocked
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 2
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 2
+    - type: AccessReader
+      access:
+      - - Captain
+      - - Command
+      - - Mercenary
+- proto: AirSensor
+  entities:
+  - uid: 37
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-14.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+  - uid: 38
+    components:
+    - type: Transform
+      pos: -6.5,-13.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 6
+  - uid: 39
+    components:
+    - type: Transform
+      pos: -6.5,-6.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 7
+  - uid: 40
+    components:
+    - type: Transform
+      pos: -10.5,-3.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 6
+      - 7
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+      - 7
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 7.5,-6.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 5
+      - 7
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 12.5,-3.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 5
+  - uid: 44
+    components:
+    - type: Transform
+      pos: 8.5,-13.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 5
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+      - 7
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 8.5,9.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 11
+  - uid: 47
+    components:
+    - type: Transform
+      pos: -8.5,0.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 10
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 9
+  - uid: 49
+    components:
+    - type: Transform
+      pos: -7.5,9.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 8
+- proto: AmeController
+  entities:
+  - uid: 50
+    components:
+    - type: Transform
+      pos: 7.5,-15.5
+      parent: 2
+    - type: AmeController
+      injecting: True
+    - type: ContainerContainer
+      containers:
+        fuelSlot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 700
+- proto: AmeJar
+  entities:
+  - uid: 51
+    components:
+    - type: Transform
+      pos: 7.3428345,-12.46193
+      parent: 2
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 7.553772,-12.46193
+      parent: 2
+  - uid: 700
+    components:
+    - type: Transform
+      parent: 50
+    - type: Physics
+      canCollide: False
+- proto: AmeShielding
+  entities:
+  - uid: 53
+    components:
+    - type: Transform
+      pos: 11.5,-14.5
+      parent: 2
+  - uid: 54
+    components:
+    - type: Transform
+      pos: 11.5,-15.5
+      parent: 2
+  - uid: 55
+    components:
+    - type: Transform
+      pos: 11.5,-16.5
+      parent: 2
+  - uid: 56
+    components:
+    - type: Transform
+      pos: 10.5,-16.5
+      parent: 2
+  - uid: 57
+    components:
+    - type: Transform
+      pos: 9.5,-16.5
+      parent: 2
+  - uid: 58
+    components:
+    - type: Transform
+      pos: 8.5,-16.5
+      parent: 2
+  - uid: 59
+    components:
+    - type: Transform
+      pos: 10.5,-15.5
+      parent: 2
+    - type: PointLight
+      radius: 1
+      enabled: True
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 10.5,-14.5
+      parent: 2
+  - uid: 61
+    components:
+    - type: Transform
+      pos: 9.5,-14.5
+      parent: 2
+  - uid: 62
+    components:
+    - type: Transform
+      pos: 9.5,-15.5
+      parent: 2
+    - type: PointLight
+      radius: 1
+      enabled: True
+  - uid: 63
+    components:
+    - type: Transform
+      pos: 8.5,-15.5
+      parent: 2
+  - uid: 64
+    components:
+    - type: Transform
+      pos: 8.5,-14.5
+      parent: 2
+- proto: AmmoTechFab
+  entities:
+  - uid: 1563
+    components:
+    - type: Transform
+      pos: -11.5,5.5
+      parent: 2
+- proto: APCBasic
+  entities:
+  - uid: 66
+    components:
+    - type: Transform
+      pos: 8.5,-9.5
+      parent: 2
+  - uid: 67
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-14.5
+      parent: 2
+  - uid: 68
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-2.5
+      parent: 2
+    - type: Apc
+      hasAccess: True
+  - uid: 69
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,9.5
+      parent: 2
+  - uid: 70
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,9.5
+      parent: 2
+  - uid: 71
+    components:
+    - type: Transform
+      pos: -6.5,-2.5
+      parent: 2
+  - uid: 72
+    components:
+    - type: Transform
+      pos: 7.5,-2.5
+      parent: 2
+- proto: AtmosDeviceFanTiny
+  entities:
+  - uid: 73
+    components:
+    - type: Transform
+      pos: -13.5,-0.5
+      parent: 2
+  - uid: 74
+    components:
+    - type: Transform
+      pos: 14.5,-0.5
+      parent: 2
+  - uid: 75
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 2
+  - uid: 76
+    components:
+    - type: Transform
+      pos: -13.5,1.5
+      parent: 2
+  - uid: 77
+    components:
+    - type: Transform
+      pos: 4.5,11.5
+      parent: 2
+  - uid: 78
+    components:
+    - type: Transform
+      pos: 14.5,1.5
+      parent: 2
+  - uid: 79
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 2
+  - uid: 80
+    components:
+    - type: Transform
+      pos: 1.5,-15.5
+      parent: 2
+  - uid: 81
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 2
+  - uid: 82
+    components:
+    - type: Transform
+      pos: 0.5,-15.5
+      parent: 2
+  - uid: 83
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 2
+  - uid: 84
+    components:
+    - type: Transform
+      pos: -0.5,-15.5
+      parent: 2
+  - uid: 85
+    components:
+    - type: Transform
+      pos: -3.5,11.5
+      parent: 2
+- proto: AtmosFixBlockerMarker
+  entities:
+  - uid: 86
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,6.5
+      parent: 2
+  - uid: 87
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,-11.5
+      parent: 2
+  - uid: 88
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,-9.5
+      parent: 2
+  - uid: 89
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,-13.5
+      parent: 2
+  - uid: 90
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,-14.5
+      parent: 2
+  - uid: 91
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,-15.5
+      parent: 2
+  - uid: 92
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,-16.5
+      parent: 2
+  - uid: 93
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,-18.5
+      parent: 2
+  - uid: 94
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-18.5
+      parent: 2
+  - uid: 95
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,-18.5
+      parent: 2
+  - uid: 96
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-18.5
+      parent: 2
+  - uid: 97
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-18.5
+      parent: 2
+  - uid: 98
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-17.5
+      parent: 2
+  - uid: 99
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-16.5
+      parent: 2
+  - uid: 100
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-16.5
+      parent: 2
+  - uid: 101
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-16.5
+      parent: 2
+  - uid: 102
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-16.5
+      parent: 2
+  - uid: 103
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-16.5
+      parent: 2
+  - uid: 104
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-17.5
+      parent: 2
+  - uid: 105
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-18.5
+      parent: 2
+  - uid: 106
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-18.5
+      parent: 2
+  - uid: 107
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-18.5
+      parent: 2
+  - uid: 109
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-18.5
+      parent: 2
+  - uid: 110
+    components:
+    - type: Transform
+      anchored: False
+      rot: 3.141592653589793 rad
+      pos: 12.5,-18.5
+      parent: 2
+  - uid: 111
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-16.5
+      parent: 2
+  - uid: 112
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-15.5
+      parent: 2
+  - uid: 113
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-14.5
+      parent: 2
+  - uid: 114
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-13.5
+      parent: 2
+  - uid: 115
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-11.5
+      parent: 2
+  - uid: 116
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-9.5
+      parent: 2
+  - uid: 117
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-6.5
+      parent: 2
+  - uid: 118
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-3.5
+      parent: 2
+  - uid: 119
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,4.5
+      parent: 2
+  - uid: 120
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,8.5
+      parent: 2
+  - uid: 121
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,12.5
+      parent: 2
+  - uid: 122
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,13.5
+      parent: 2
+  - uid: 123
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,14.5
+      parent: 2
+  - uid: 124
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,14.5
+      parent: 2
+  - uid: 138
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,11.5
+      parent: 2
+  - uid: 139
+    components:
+    - type: Transform
+      anchored: False
+      rot: 3.141592653589793 rad
+      pos: -2.5,12.5
+      parent: 2
+  - uid: 140
+    components:
+    - type: Transform
+      anchored: False
+      rot: 3.141592653589793 rad
+      pos: -2.5,10.5
+      parent: 2
+  - uid: 141
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,8.5
+      parent: 2
+  - uid: 142
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,7.5
+      parent: 2
+  - uid: 143
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,7.5
+      parent: 2
+  - uid: 144
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,7.5
+      parent: 2
+  - uid: 147
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,4.5
+      parent: 2
+  - uid: 148
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,7.5
+      parent: 2
+  - uid: 149
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,7.5
+      parent: 2
+  - uid: 150
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,6.5
+      parent: 2
+  - uid: 151
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,8.5
+      parent: 2
+  - uid: 152
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,4.5
+      parent: 2
+  - uid: 153
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,3.5
+      parent: 2
+  - uid: 154
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,2.5
+      parent: 2
+  - uid: 155
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,1.5
+      parent: 2
+  - uid: 156
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,0.5
+      parent: 2
+  - uid: 157
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,0.5
+      parent: 2
+  - uid: 158
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-0.5
+      parent: 2
+  - uid: 159
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-1.5
+      parent: 2
+  - uid: 160
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-1.5
+      parent: 2
+  - uid: 161
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-2.5
+      parent: 2
+  - uid: 162
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-2.5
+      parent: 2
+  - uid: 163
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-3.5
+      parent: 2
+  - uid: 164
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-3.5
+      parent: 2
+  - uid: 165
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,4.5
+      parent: 2
+  - uid: 166
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,3.5
+      parent: 2
+  - uid: 167
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,4.5
+      parent: 2
+  - uid: 168
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,3.5
+      parent: 2
+  - uid: 169
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,3.5
+      parent: 2
+  - uid: 170
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,2.5
+      parent: 2
+  - uid: 171
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,0.5
+      parent: 2
+  - uid: 172
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,-3.5
+      parent: 2
+  - uid: 173
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,1.5
+      parent: 2
+  - uid: 174
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,0.5
+      parent: 2
+  - uid: 175
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-0.5
+      parent: 2
+  - uid: 176
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-1.5
+      parent: 2
+  - uid: 177
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-1.5
+      parent: 2
+  - uid: 178
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-2.5
+      parent: 2
+  - uid: 179
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-3.5
+      parent: 2
+  - uid: 180
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-3.5
+      parent: 2
+  - uid: 181
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-2.5
+      parent: 2
+  - uid: 182
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,14.5
+      parent: 2
+  - uid: 183
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,14.5
+      parent: 2
+  - uid: 184
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,13.5
+      parent: 2
+  - uid: 185
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,12.5
+      parent: 2
+  - uid: 186
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,10.5
+      parent: 2
+  - uid: 187
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,9.5
+      parent: 2
+  - uid: 188
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,8.5
+      parent: 2
+  - uid: 189
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,4.5
+      parent: 2
+  - uid: 190
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,-6.5
+      parent: 2
+  - uid: 194
+    components:
+    - type: Transform
+      pos: 4.5,-0.5
+      parent: 2
+  - uid: 698
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,9.5
+      parent: 2
+  - uid: 1018
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 2
+  - uid: 1668
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,13.5
+      parent: 2
+  - uid: 1669
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,8.5
+      parent: 2
+  - uid: 1670
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,9.5
+      parent: 2
+  - uid: 1671
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,9.5
+      parent: 2
+  - uid: 1672
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,9.5
+      parent: 2
+  - uid: 1673
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,9.5
+      parent: 2
+  - uid: 1674
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,8.5
+      parent: 2
+  - uid: 1675
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,8.5
+      parent: 2
+  - uid: 1676
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,9.5
+      parent: 2
+  - uid: 1677
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,9.5
+      parent: 2
+  - uid: 1678
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,9.5
+      parent: 2
+  - uid: 1679
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,11.5
+      parent: 2
+  - uid: 1680
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,12.5
+      parent: 2
+  - uid: 1681
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,13.5
+      parent: 2
+  - uid: 1682
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,13.5
+      parent: 2
+  - uid: 1683
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,13.5
+      parent: 2
+  - uid: 1684
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,13.5
+      parent: 2
+  - uid: 1685
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,14.5
+      parent: 2
+  - uid: 1686
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,13.5
+      parent: 2
+  - uid: 1687
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,13.5
+      parent: 2
+  - uid: 1688
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,10.5
+      parent: 2
+  - uid: 1690
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,10.5
+      parent: 2
+  - uid: 1691
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,10.5
+      parent: 2
+  - uid: 1741
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,10.5
+      parent: 2
+- proto: Autolathe
+  entities:
+  - uid: 1236
+    components:
+    - type: Transform
+      pos: -10.5,7.5
+      parent: 2
+- proto: BarricadeBlock
+  entities:
+  - uid: 1168
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-8.5
+      parent: 2
+- proto: BarricadeDirectional
+  entities:
+  - uid: 195
+    components:
+    - type: Transform
+      pos: -9.5,-7.5
+      parent: 2
+- proto: BlastDoor
+  entities:
+  - uid: 192
+    components:
+    - type: Transform
+      pos: 3.5,10.5
+      parent: 2
+  - uid: 199
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,11.5
+      parent: 2
+  - uid: 200
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-15.5
+      parent: 2
+  - uid: 201
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-15.5
+      parent: 2
+  - uid: 202
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-15.5
+      parent: 2
+  - uid: 203
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,11.5
+      parent: 2
+  - uid: 1237
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,13.5
+      parent: 2
+  - uid: 1612
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,13.5
+      parent: 2
+  - uid: 1666
+    components:
+    - type: Transform
+      pos: -2.5,10.5
+      parent: 2
+- proto: BlastDoorOpen
+  entities:
+  - uid: 204
+    components:
+    - type: Transform
+      pos: -12.5,-0.5
+      parent: 2
+  - uid: 205
+    components:
+    - type: Transform
+      pos: -12.5,1.5
+      parent: 2
+  - uid: 206
+    components:
+    - type: Transform
+      pos: 13.5,1.5
+      parent: 2
+  - uid: 207
+    components:
+    - type: Transform
+      pos: 13.5,-0.5
+      parent: 2
+- proto: BoxBeanbag
+  entities:
+  - uid: 1740
+    components:
+    - type: Transform
+      pos: 12.644245,5.283481
+      parent: 2
+- proto: BoxHandcuff
+  entities:
+  - uid: 209
+    components:
+    - type: Transform
+      pos: 9.662808,4.682262
+      parent: 2
+- proto: BoxLethalshot
+  entities:
+  - uid: 1238
+    components:
+    - type: Transform
+      pos: 12.47237,5.611606
+      parent: 2
+  - uid: 1736
+    components:
+    - type: Transform
+      pos: 10.47237,4.424106
+      parent: 2
+- proto: BoxShotgunFlare
+  entities:
+  - uid: 662
+    components:
+    - type: Transform
+      pos: 12.53487,4.424106
+      parent: 2
+- proto: BoxShotgunSlug
+  entities:
+  - uid: 1742
+    components:
+    - type: Transform
+      pos: 11.362995,4.549106
+      parent: 2
+- proto: BoxZiptie
+  entities:
+  - uid: 1734
+    components:
+    - type: Transform
+      pos: 9.31488,4.338512
+      parent: 2
+- proto: ButtonFrameCautionSecurity
+  entities:
+  - uid: 210
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 2
+  - uid: 211
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 2
+- proto: CableApcExtension
+  entities:
+  - uid: 212
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 2
+  - uid: 213
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 2
+  - uid: 214
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 2
+  - uid: 215
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 2
+  - uid: 216
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 2
+  - uid: 217
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 2
+  - uid: 218
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 2
+  - uid: 219
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 2
+  - uid: 220
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 2
+  - uid: 221
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 2
+  - uid: 222
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 2
+  - uid: 223
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 2
+  - uid: 224
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 2
+  - uid: 225
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 2
+  - uid: 226
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 2
+  - uid: 227
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 2
+  - uid: 228
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 2
+  - uid: 229
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 2
+  - uid: 230
+    components:
+    - type: Transform
+      pos: 5.5,9.5
+      parent: 2
+  - uid: 231
+    components:
+    - type: Transform
+      pos: 6.5,9.5
+      parent: 2
+  - uid: 232
+    components:
+    - type: Transform
+      pos: 8.5,-10.5
+      parent: 2
+  - uid: 233
+    components:
+    - type: Transform
+      pos: 8.5,9.5
+      parent: 2
+  - uid: 234
+    components:
+    - type: Transform
+      pos: 9.5,9.5
+      parent: 2
+  - uid: 235
+    components:
+    - type: Transform
+      pos: 10.5,9.5
+      parent: 2
+  - uid: 236
+    components:
+    - type: Transform
+      pos: 7.5,9.5
+      parent: 2
+  - uid: 237
+    components:
+    - type: Transform
+      pos: 7.5,8.5
+      parent: 2
+  - uid: 238
+    components:
+    - type: Transform
+      pos: 7.5,7.5
+      parent: 2
+  - uid: 239
+    components:
+    - type: Transform
+      pos: 7.5,6.5
+      parent: 2
+  - uid: 240
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 2
+  - uid: 241
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 2
+  - uid: 242
+    components:
+    - type: Transform
+      pos: 9.5,5.5
+      parent: 2
+  - uid: 243
+    components:
+    - type: Transform
+      pos: 10.5,5.5
+      parent: 2
+  - uid: 244
+    components:
+    - type: Transform
+      pos: 11.5,5.5
+      parent: 2
+  - uid: 245
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 2
+  - uid: 246
+    components:
+    - type: Transform
+      pos: -5.5,9.5
+      parent: 2
+  - uid: 247
+    components:
+    - type: Transform
+      pos: -6.5,9.5
+      parent: 2
+  - uid: 248
+    components:
+    - type: Transform
+      pos: -7.5,9.5
+      parent: 2
+  - uid: 249
+    components:
+    - type: Transform
+      pos: -8.5,9.5
+      parent: 2
+  - uid: 251
+    components:
+    - type: Transform
+      pos: 7.5,10.5
+      parent: 2
+  - uid: 252
+    components:
+    - type: Transform
+      pos: 7.5,11.5
+      parent: 2
+  - uid: 253
+    components:
+    - type: Transform
+      pos: -6.5,10.5
+      parent: 2
+  - uid: 254
+    components:
+    - type: Transform
+      pos: -6.5,11.5
+      parent: 2
+  - uid: 255
+    components:
+    - type: Transform
+      pos: -7.5,8.5
+      parent: 2
+  - uid: 256
+    components:
+    - type: Transform
+      pos: -7.5,7.5
+      parent: 2
+  - uid: 257
+    components:
+    - type: Transform
+      pos: -7.5,6.5
+      parent: 2
+  - uid: 258
+    components:
+    - type: Transform
+      pos: -7.5,5.5
+      parent: 2
+  - uid: 259
+    components:
+    - type: Transform
+      pos: -7.5,4.5
+      parent: 2
+  - uid: 260
+    components:
+    - type: Transform
+      pos: -8.5,6.5
+      parent: 2
+  - uid: 261
+    components:
+    - type: Transform
+      pos: -9.5,6.5
+      parent: 2
+  - uid: 262
+    components:
+    - type: Transform
+      pos: -9.5,5.5
+      parent: 2
+  - uid: 263
+    components:
+    - type: Transform
+      pos: -10.5,5.5
+      parent: 2
+  - uid: 264
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 2
+  - uid: 265
+    components:
+    - type: Transform
+      pos: -6.5,-2.5
+      parent: 2
+  - uid: 266
+    components:
+    - type: Transform
+      pos: -6.5,-3.5
+      parent: 2
+  - uid: 267
+    components:
+    - type: Transform
+      pos: -6.5,-4.5
+      parent: 2
+  - uid: 268
+    components:
+    - type: Transform
+      pos: 8.5,-11.5
+      parent: 2
+  - uid: 269
+    components:
+    - type: Transform
+      pos: -6.5,-5.5
+      parent: 2
+  - uid: 270
+    components:
+    - type: Transform
+      pos: -5.5,-5.5
+      parent: 2
+  - uid: 271
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 2
+  - uid: 272
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 2
+  - uid: 273
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 2
+  - uid: 274
+    components:
+    - type: Transform
+      pos: 8.5,-9.5
+      parent: 2
+  - uid: 275
+    components:
+    - type: Transform
+      pos: -7.5,-5.5
+      parent: 2
+  - uid: 276
+    components:
+    - type: Transform
+      pos: -7.5,-6.5
+      parent: 2
+  - uid: 277
+    components:
+    - type: Transform
+      pos: -8.5,-6.5
+      parent: 2
+  - uid: 278
+    components:
+    - type: Transform
+      pos: -11.5,-0.5
+      parent: 2
+  - uid: 279
+    components:
+    - type: Transform
+      pos: -9.5,-6.5
+      parent: 2
+  - uid: 280
+    components:
+    - type: Transform
+      pos: -10.5,-6.5
+      parent: 2
+  - uid: 281
+    components:
+    - type: Transform
+      pos: -10.5,-5.5
+      parent: 2
+  - uid: 282
+    components:
+    - type: Transform
+      pos: -10.5,-4.5
+      parent: 2
+  - uid: 283
+    components:
+    - type: Transform
+      pos: 7.5,-2.5
+      parent: 2
+  - uid: 284
+    components:
+    - type: Transform
+      pos: 7.5,-3.5
+      parent: 2
+  - uid: 285
+    components:
+    - type: Transform
+      pos: 8.5,-3.5
+      parent: 2
+  - uid: 286
+    components:
+    - type: Transform
+      pos: 8.5,-4.5
+      parent: 2
+  - uid: 287
+    components:
+    - type: Transform
+      pos: 8.5,-5.5
+      parent: 2
+  - uid: 288
+    components:
+    - type: Transform
+      pos: 7.5,-5.5
+      parent: 2
+  - uid: 289
+    components:
+    - type: Transform
+      pos: 6.5,-5.5
+      parent: 2
+  - uid: 290
+    components:
+    - type: Transform
+      pos: 5.5,-5.5
+      parent: 2
+  - uid: 291
+    components:
+    - type: Transform
+      pos: 4.5,-5.5
+      parent: 2
+  - uid: 292
+    components:
+    - type: Transform
+      pos: 3.5,-5.5
+      parent: 2
+  - uid: 293
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
+      parent: 2
+  - uid: 294
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 2
+  - uid: 295
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 2
+  - uid: 296
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 2
+  - uid: 297
+    components:
+    - type: Transform
+      pos: -1.5,-8.5
+      parent: 2
+  - uid: 298
+    components:
+    - type: Transform
+      pos: -1.5,-9.5
+      parent: 2
+  - uid: 299
+    components:
+    - type: Transform
+      pos: -1.5,-10.5
+      parent: 2
+  - uid: 300
+    components:
+    - type: Transform
+      pos: -1.5,-11.5
+      parent: 2
+  - uid: 301
+    components:
+    - type: Transform
+      pos: -1.5,-12.5
+      parent: 2
+  - uid: 302
+    components:
+    - type: Transform
+      pos: -1.5,-13.5
+      parent: 2
+  - uid: 303
+    components:
+    - type: Transform
+      pos: -1.5,-14.5
+      parent: 2
+  - uid: 304
+    components:
+    - type: Transform
+      pos: 2.5,-6.5
+      parent: 2
+  - uid: 305
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 2
+  - uid: 306
+    components:
+    - type: Transform
+      pos: 2.5,-8.5
+      parent: 2
+  - uid: 307
+    components:
+    - type: Transform
+      pos: 2.5,-9.5
+      parent: 2
+  - uid: 308
+    components:
+    - type: Transform
+      pos: 2.5,-10.5
+      parent: 2
+  - uid: 309
+    components:
+    - type: Transform
+      pos: 2.5,-11.5
+      parent: 2
+  - uid: 310
+    components:
+    - type: Transform
+      pos: 2.5,-12.5
+      parent: 2
+  - uid: 311
+    components:
+    - type: Transform
+      pos: 2.5,-13.5
+      parent: 2
+  - uid: 312
+    components:
+    - type: Transform
+      pos: 2.5,-14.5
+      parent: 2
+  - uid: 313
+    components:
+    - type: Transform
+      pos: 8.5,-12.5
+      parent: 2
+  - uid: 314
+    components:
+    - type: Transform
+      pos: 9.5,-12.5
+      parent: 2
+  - uid: 315
+    components:
+    - type: Transform
+      pos: 10.5,-12.5
+      parent: 2
+  - uid: 316
+    components:
+    - type: Transform
+      pos: 10.5,-11.5
+      parent: 2
+  - uid: 317
+    components:
+    - type: Transform
+      pos: 10.5,-10.5
+      parent: 2
+  - uid: 318
+    components:
+    - type: Transform
+      pos: 10.5,-9.5
+      parent: 2
+  - uid: 319
+    components:
+    - type: Transform
+      pos: 10.5,-8.5
+      parent: 2
+  - uid: 320
+    components:
+    - type: Transform
+      pos: 7.5,-7.5
+      parent: 2
+  - uid: 321
+    components:
+    - type: Transform
+      pos: 4.5,-7.5
+      parent: 2
+  - uid: 322
+    components:
+    - type: Transform
+      pos: 8.5,-7.5
+      parent: 2
+  - uid: 323
+    components:
+    - type: Transform
+      pos: 7.5,-12.5
+      parent: 2
+  - uid: 324
+    components:
+    - type: Transform
+      pos: 6.5,-12.5
+      parent: 2
+  - uid: 325
+    components:
+    - type: Transform
+      pos: 5.5,-12.5
+      parent: 2
+  - uid: 326
+    components:
+    - type: Transform
+      pos: 5.5,-13.5
+      parent: 2
+  - uid: 327
+    components:
+    - type: Transform
+      pos: 5.5,-14.5
+      parent: 2
+  - uid: 328
+    components:
+    - type: Transform
+      pos: 5.5,-15.5
+      parent: 2
+  - uid: 329
+    components:
+    - type: Transform
+      pos: 8.5,-13.5
+      parent: 2
+  - uid: 330
+    components:
+    - type: Transform
+      pos: 8.5,-14.5
+      parent: 2
+  - uid: 331
+    components:
+    - type: Transform
+      pos: 8.5,-15.5
+      parent: 2
+  - uid: 332
+    components:
+    - type: Transform
+      pos: 8.5,-16.5
+      parent: 2
+  - uid: 333
+    components:
+    - type: Transform
+      pos: 8.5,-17.5
+      parent: 2
+  - uid: 334
+    components:
+    - type: Transform
+      pos: 9.5,-17.5
+      parent: 2
+  - uid: 335
+    components:
+    - type: Transform
+      pos: -11.5,-14.5
+      parent: 2
+  - uid: 336
+    components:
+    - type: Transform
+      pos: -10.5,-14.5
+      parent: 2
+  - uid: 337
+    components:
+    - type: Transform
+      pos: -9.5,-14.5
+      parent: 2
+  - uid: 338
+    components:
+    - type: Transform
+      pos: -9.5,-14.5
+      parent: 2
+  - uid: 339
+    components:
+    - type: Transform
+      pos: -9.5,-15.5
+      parent: 2
+  - uid: 340
+    components:
+    - type: Transform
+      pos: -9.5,-16.5
+      parent: 2
+  - uid: 341
+    components:
+    - type: Transform
+      pos: -9.5,-17.5
+      parent: 2
+  - uid: 342
+    components:
+    - type: Transform
+      pos: -8.5,-17.5
+      parent: 2
+  - uid: 343
+    components:
+    - type: Transform
+      pos: -9.5,-13.5
+      parent: 2
+  - uid: 344
+    components:
+    - type: Transform
+      pos: -9.5,-12.5
+      parent: 2
+  - uid: 347
+    components:
+    - type: Transform
+      pos: -8.5,-10.5
+      parent: 2
+  - uid: 348
+    components:
+    - type: Transform
+      pos: -7.5,-10.5
+      parent: 2
+  - uid: 349
+    components:
+    - type: Transform
+      pos: -6.5,-10.5
+      parent: 2
+  - uid: 350
+    components:
+    - type: Transform
+      pos: -5.5,-10.5
+      parent: 2
+  - uid: 351
+    components:
+    - type: Transform
+      pos: -5.5,-11.5
+      parent: 2
+  - uid: 352
+    components:
+    - type: Transform
+      pos: -5.5,-12.5
+      parent: 2
+  - uid: 353
+    components:
+    - type: Transform
+      pos: -5.5,-13.5
+      parent: 2
+  - uid: 354
+    components:
+    - type: Transform
+      pos: -5.5,-14.5
+      parent: 2
+  - uid: 355
+    components:
+    - type: Transform
+      pos: -5.5,-15.5
+      parent: 2
+  - uid: 356
+    components:
+    - type: Transform
+      pos: -5.5,-16.5
+      parent: 2
+  - uid: 357
+    components:
+    - type: Transform
+      pos: -7.5,-7.5
+      parent: 2
+  - uid: 358
+    components:
+    - type: Transform
+      pos: -6.5,-7.5
+      parent: 2
+  - uid: 359
+    components:
+    - type: Transform
+      pos: -5.5,-7.5
+      parent: 2
+  - uid: 360
+    components:
+    - type: Transform
+      pos: -4.5,-7.5
+      parent: 2
+  - uid: 361
+    components:
+    - type: Transform
+      pos: 8.5,-6.5
+      parent: 2
+  - uid: 362
+    components:
+    - type: Transform
+      pos: 8.5,-7.5
+      parent: 2
+  - uid: 363
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 2
+  - uid: 364
+    components:
+    - type: Transform
+      pos: -9.5,-8.5
+      parent: 2
+  - uid: 365
+    components:
+    - type: Transform
+      pos: -9.5,-9.5
+      parent: 2
+  - uid: 366
+    components:
+    - type: Transform
+      pos: 6.5,-7.5
+      parent: 2
+  - uid: 367
+    components:
+    - type: Transform
+      pos: 5.5,-7.5
+      parent: 2
+  - uid: 368
+    components:
+    - type: Transform
+      pos: -7.5,2.5
+      parent: 2
+  - uid: 369
+    components:
+    - type: Transform
+      pos: -7.5,1.5
+      parent: 2
+  - uid: 370
+    components:
+    - type: Transform
+      pos: -7.5,0.5
+      parent: 2
+  - uid: 371
+    components:
+    - type: Transform
+      pos: 8.5,4.5
+      parent: 2
+  - uid: 372
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 2
+  - uid: 373
+    components:
+    - type: Transform
+      pos: 8.5,2.5
+      parent: 2
+  - uid: 374
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 2
+  - uid: 375
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 2
+  - uid: 376
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 2
+  - uid: 377
+    components:
+    - type: Transform
+      pos: 10.5,0.5
+      parent: 2
+  - uid: 378
+    components:
+    - type: Transform
+      pos: 11.5,0.5
+      parent: 2
+  - uid: 379
+    components:
+    - type: Transform
+      pos: 11.5,1.5
+      parent: 2
+  - uid: 380
+    components:
+    - type: Transform
+      pos: 11.5,-0.5
+      parent: 2
+  - uid: 381
+    components:
+    - type: Transform
+      pos: 12.5,1.5
+      parent: 2
+  - uid: 382
+    components:
+    - type: Transform
+      pos: 12.5,-0.5
+      parent: 2
+  - uid: 383
+    components:
+    - type: Transform
+      pos: -8.5,0.5
+      parent: 2
+  - uid: 384
+    components:
+    - type: Transform
+      pos: -9.5,0.5
+      parent: 2
+  - uid: 385
+    components:
+    - type: Transform
+      pos: -10.5,0.5
+      parent: 2
+  - uid: 386
+    components:
+    - type: Transform
+      pos: -10.5,1.5
+      parent: 2
+  - uid: 387
+    components:
+    - type: Transform
+      pos: -10.5,-0.5
+      parent: 2
+  - uid: 388
+    components:
+    - type: Transform
+      pos: -5.5,11.5
+      parent: 2
+  - uid: 389
+    components:
+    - type: Transform
+      pos: -11.5,1.5
+      parent: 2
+  - uid: 390
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 2
+  - uid: 391
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 2
+  - uid: 392
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 2
+  - uid: 393
+    components:
+    - type: Transform
+      pos: 6.5,-0.5
+      parent: 2
+  - uid: 394
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 2
+  - uid: 395
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 2
+  - uid: 396
+    components:
+    - type: Transform
+      pos: -4.5,11.5
+      parent: 2
+  - uid: 397
+    components:
+    - type: Transform
+      pos: 6.5,11.5
+      parent: 2
+  - uid: 398
+    components:
+    - type: Transform
+      pos: 5.5,11.5
+      parent: 2
+  - uid: 399
+    components:
+    - type: Transform
+      pos: -3.5,11.5
+      parent: 2
+  - uid: 400
+    components:
+    - type: Transform
+      pos: 4.5,11.5
+      parent: 2
+  - uid: 402
+    components:
+    - type: Transform
+      pos: 10.5,-13.5
+      parent: 2
+  - uid: 403
+    components:
+    - type: Transform
+      pos: 11.5,-13.5
+      parent: 2
+  - uid: 404
+    components:
+    - type: Transform
+      pos: 12.5,-13.5
+      parent: 2
+  - uid: 405
+    components:
+    - type: Transform
+      pos: 12.5,-14.5
+      parent: 2
+  - uid: 406
+    components:
+    - type: Transform
+      pos: 12.5,-15.5
+      parent: 2
+  - uid: 1011
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 2
+  - uid: 1073
+    components:
+    - type: Transform
+      pos: -9.5,9.5
+      parent: 2
+  - uid: 1173
+    components:
+    - type: Transform
+      pos: -1.5,11.5
+      parent: 2
+  - uid: 1656
+    components:
+    - type: Transform
+      pos: -2.5,11.5
+      parent: 2
+  - uid: 1657
+    components:
+    - type: Transform
+      pos: 3.5,11.5
+      parent: 2
+  - uid: 1659
+    components:
+    - type: Transform
+      pos: 2.5,11.5
+      parent: 2
+  - uid: 1781
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 2
+- proto: CableApcStack1
+  entities:
+  - uid: 191
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.469639,-14.147763
+      parent: 2
+  - uid: 208
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.605055,-12.366513
+      parent: 2
+  - uid: 985
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.188389,-14.637347
+      parent: 2
+- proto: CableHV
+  entities:
+  - uid: 410
+    components:
+    - type: Transform
+      pos: 9.5,-7.5
+      parent: 2
+  - uid: 411
+    components:
+    - type: Transform
+      pos: 7.5,-15.5
+      parent: 2
+  - uid: 412
+    components:
+    - type: Transform
+      pos: 6.5,-15.5
+      parent: 2
+  - uid: 413
+    components:
+    - type: Transform
+      pos: 5.5,-15.5
+      parent: 2
+  - uid: 414
+    components:
+    - type: Transform
+      pos: 5.5,-14.5
+      parent: 2
+  - uid: 415
+    components:
+    - type: Transform
+      pos: 5.5,-16.5
+      parent: 2
+  - uid: 416
+    components:
+    - type: Transform
+      pos: 4.5,-16.5
+      parent: 2
+  - uid: 417
+    components:
+    - type: Transform
+      pos: 4.5,-15.5
+      parent: 2
+  - uid: 418
+    components:
+    - type: Transform
+      pos: 4.5,-14.5
+      parent: 2
+  - uid: 419
+    components:
+    - type: Transform
+      pos: 4.5,-13.5
+      parent: 2
+  - uid: 420
+    components:
+    - type: Transform
+      pos: 4.5,-12.5
+      parent: 2
+  - uid: 421
+    components:
+    - type: Transform
+      pos: 5.5,-12.5
+      parent: 2
+  - uid: 422
+    components:
+    - type: Transform
+      pos: 6.5,-12.5
+      parent: 2
+  - uid: 423
+    components:
+    - type: Transform
+      pos: 7.5,-12.5
+      parent: 2
+  - uid: 424
+    components:
+    - type: Transform
+      pos: 8.5,-12.5
+      parent: 2
+  - uid: 425
+    components:
+    - type: Transform
+      pos: 9.5,-12.5
+      parent: 2
+  - uid: 426
+    components:
+    - type: Transform
+      pos: 10.5,-12.5
+      parent: 2
+  - uid: 427
+    components:
+    - type: Transform
+      pos: 10.5,-10.5
+      parent: 2
+  - uid: 428
+    components:
+    - type: Transform
+      pos: 10.5,-9.5
+      parent: 2
+  - uid: 429
+    components:
+    - type: Transform
+      pos: 10.5,-8.5
+      parent: 2
+  - uid: 430
+    components:
+    - type: Transform
+      pos: 10.5,-7.5
+      parent: 2
+  - uid: 431
+    components:
+    - type: Transform
+      pos: 8.5,-7.5
+      parent: 2
+  - uid: 432
+    components:
+    - type: Transform
+      pos: 7.5,-7.5
+      parent: 2
+  - uid: 433
+    components:
+    - type: Transform
+      pos: 8.5,-6.5
+      parent: 2
+  - uid: 434
+    components:
+    - type: Transform
+      pos: 8.5,-5.5
+      parent: 2
+  - uid: 435
+    components:
+    - type: Transform
+      pos: 8.5,-4.5
+      parent: 2
+  - uid: 436
+    components:
+    - type: Transform
+      pos: 8.5,-3.5
+      parent: 2
+  - uid: 437
+    components:
+    - type: Transform
+      pos: 8.5,-2.5
+      parent: 2
+  - uid: 438
+    components:
+    - type: Transform
+      pos: 8.5,-1.5
+      parent: 2
+  - uid: 439
+    components:
+    - type: Transform
+      pos: 8.5,-0.5
+      parent: 2
+  - uid: 440
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 2
+  - uid: 441
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 2
+  - uid: 442
+    components:
+    - type: Transform
+      pos: 8.5,2.5
+      parent: 2
+  - uid: 443
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 2
+  - uid: 444
+    components:
+    - type: Transform
+      pos: 8.5,4.5
+      parent: 2
+  - uid: 445
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 2
+  - uid: 446
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 2
+  - uid: 447
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 2
+  - uid: 448
+    components:
+    - type: Transform
+      pos: 6.5,-7.5
+      parent: 2
+  - uid: 449
+    components:
+    - type: Transform
+      pos: 5.5,-7.5
+      parent: 2
+  - uid: 450
+    components:
+    - type: Transform
+      pos: 4.5,-7.5
+      parent: 2
+  - uid: 451
+    components:
+    - type: Transform
+      pos: 3.5,-7.5
+      parent: 2
+  - uid: 452
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 2
+  - uid: 453
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 2
+  - uid: 454
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 2
+  - uid: 455
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 2
+  - uid: 456
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 2
+  - uid: 457
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 2
+  - uid: 458
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 2
+  - uid: 459
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 2
+  - uid: 460
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 2
+  - uid: 461
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 2
+  - uid: 462
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 2
+  - uid: 463
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 2
+  - uid: 464
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 2
+  - uid: 465
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 2
+  - uid: 466
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 2
+  - uid: 467
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 2
+  - uid: 468
+    components:
+    - type: Transform
+      pos: -0.5,-7.5
+      parent: 2
+  - uid: 469
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 2
+  - uid: 470
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 2
+  - uid: 471
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 2
+  - uid: 472
+    components:
+    - type: Transform
+      pos: -4.5,-7.5
+      parent: 2
+  - uid: 473
+    components:
+    - type: Transform
+      pos: -5.5,-7.5
+      parent: 2
+  - uid: 474
+    components:
+    - type: Transform
+      pos: -6.5,-7.5
+      parent: 2
+  - uid: 475
+    components:
+    - type: Transform
+      pos: -7.5,-7.5
+      parent: 2
+  - uid: 476
+    components:
+    - type: Transform
+      pos: -7.5,-7.5
+      parent: 2
+  - uid: 477
+    components:
+    - type: Transform
+      pos: -7.5,-6.5
+      parent: 2
+  - uid: 478
+    components:
+    - type: Transform
+      pos: -7.5,-5.5
+      parent: 2
+  - uid: 479
+    components:
+    - type: Transform
+      pos: -7.5,-4.5
+      parent: 2
+  - uid: 480
+    components:
+    - type: Transform
+      pos: -7.5,-3.5
+      parent: 2
+  - uid: 481
+    components:
+    - type: Transform
+      pos: -7.5,-2.5
+      parent: 2
+  - uid: 482
+    components:
+    - type: Transform
+      pos: -7.5,-1.5
+      parent: 2
+  - uid: 483
+    components:
+    - type: Transform
+      pos: -7.5,-0.5
+      parent: 2
+  - uid: 484
+    components:
+    - type: Transform
+      pos: -7.5,0.5
+      parent: 2
+  - uid: 485
+    components:
+    - type: Transform
+      pos: -7.5,1.5
+      parent: 2
+  - uid: 486
+    components:
+    - type: Transform
+      pos: -7.5,2.5
+      parent: 2
+  - uid: 487
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 2
+  - uid: 488
+    components:
+    - type: Transform
+      pos: -7.5,4.5
+      parent: 2
+  - uid: 489
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 2
+  - uid: 490
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 2
+  - uid: 491
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 2
+  - uid: 492
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 2
+  - uid: 493
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 2
+  - uid: 494
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 2
+  - uid: 495
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 2
+  - uid: 496
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 2
+  - uid: 497
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 2
+  - uid: 498
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 2
+  - uid: 499
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 2
+  - uid: 500
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 2
+  - uid: 501
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 2
+  - uid: 502
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 2
+  - uid: 503
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 2
+  - uid: 504
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 2
+  - uid: 505
+    components:
+    - type: Transform
+      pos: 10.5,-11.5
+      parent: 2
+- proto: CableMV
+  entities:
+  - uid: 506
+    components:
+    - type: Transform
+      pos: 5.5,-12.5
+      parent: 2
+  - uid: 507
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 2
+  - uid: 508
+    components:
+    - type: Transform
+      pos: 10.5,-10.5
+      parent: 2
+  - uid: 509
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 2
+  - uid: 510
+    components:
+    - type: Transform
+      pos: 5.5,-16.5
+      parent: 2
+  - uid: 511
+    components:
+    - type: Transform
+      pos: 5.5,-15.5
+      parent: 2
+  - uid: 512
+    components:
+    - type: Transform
+      pos: 5.5,-14.5
+      parent: 2
+  - uid: 513
+    components:
+    - type: Transform
+      pos: 5.5,-13.5
+      parent: 2
+  - uid: 514
+    components:
+    - type: Transform
+      pos: 5.5,-12.5
+      parent: 2
+  - uid: 515
+    components:
+    - type: Transform
+      pos: 6.5,-12.5
+      parent: 2
+  - uid: 516
+    components:
+    - type: Transform
+      pos: 7.5,-12.5
+      parent: 2
+  - uid: 517
+    components:
+    - type: Transform
+      pos: 8.5,-12.5
+      parent: 2
+  - uid: 518
+    components:
+    - type: Transform
+      pos: 9.5,-12.5
+      parent: 2
+  - uid: 519
+    components:
+    - type: Transform
+      pos: 10.5,-12.5
+      parent: 2
+  - uid: 520
+    components:
+    - type: Transform
+      pos: 10.5,-11.5
+      parent: 2
+  - uid: 521
+    components:
+    - type: Transform
+      pos: 8.5,-12.5
+      parent: 2
+  - uid: 522
+    components:
+    - type: Transform
+      pos: 8.5,-11.5
+      parent: 2
+  - uid: 523
+    components:
+    - type: Transform
+      pos: 8.5,-10.5
+      parent: 2
+  - uid: 524
+    components:
+    - type: Transform
+      pos: 8.5,-9.5
+      parent: 2
+  - uid: 525
+    components:
+    - type: Transform
+      pos: 10.5,-9.5
+      parent: 2
+  - uid: 526
+    components:
+    - type: Transform
+      pos: 10.5,-8.5
+      parent: 2
+  - uid: 527
+    components:
+    - type: Transform
+      pos: 10.5,-7.5
+      parent: 2
+  - uid: 528
+    components:
+    - type: Transform
+      pos: 9.5,-7.5
+      parent: 2
+  - uid: 529
+    components:
+    - type: Transform
+      pos: 8.5,-7.5
+      parent: 2
+  - uid: 530
+    components:
+    - type: Transform
+      pos: 8.5,-6.5
+      parent: 2
+  - uid: 531
+    components:
+    - type: Transform
+      pos: 8.5,-5.5
+      parent: 2
+  - uid: 532
+    components:
+    - type: Transform
+      pos: 8.5,-4.5
+      parent: 2
+  - uid: 533
+    components:
+    - type: Transform
+      pos: 8.5,-3.5
+      parent: 2
+  - uid: 534
+    components:
+    - type: Transform
+      pos: 7.5,-3.5
+      parent: 2
+  - uid: 535
+    components:
+    - type: Transform
+      pos: 7.5,-2.5
+      parent: 2
+  - uid: 536
+    components:
+    - type: Transform
+      pos: 7.5,-7.5
+      parent: 2
+  - uid: 537
+    components:
+    - type: Transform
+      pos: 6.5,-7.5
+      parent: 2
+  - uid: 538
+    components:
+    - type: Transform
+      pos: 5.5,-7.5
+      parent: 2
+  - uid: 539
+    components:
+    - type: Transform
+      pos: 4.5,-7.5
+      parent: 2
+  - uid: 540
+    components:
+    - type: Transform
+      pos: 3.5,-7.5
+      parent: 2
+  - uid: 541
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 2
+  - uid: 542
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 2
+  - uid: 543
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 2
+  - uid: 544
+    components:
+    - type: Transform
+      pos: -0.5,-7.5
+      parent: 2
+  - uid: 545
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 2
+  - uid: 546
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 2
+  - uid: 547
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 2
+  - uid: 548
+    components:
+    - type: Transform
+      pos: -4.5,-7.5
+      parent: 2
+  - uid: 549
+    components:
+    - type: Transform
+      pos: -5.5,-7.5
+      parent: 2
+  - uid: 550
+    components:
+    - type: Transform
+      pos: -6.5,-7.5
+      parent: 2
+  - uid: 551
+    components:
+    - type: Transform
+      pos: -7.5,-7.5
+      parent: 2
+  - uid: 552
+    components:
+    - type: Transform
+      pos: -8.5,-7.5
+      parent: 2
+  - uid: 553
+    components:
+    - type: Transform
+      pos: -9.5,-7.5
+      parent: 2
+  - uid: 554
+    components:
+    - type: Transform
+      pos: -9.5,-7.5
+      parent: 2
+  - uid: 555
+    components:
+    - type: Transform
+      pos: -9.5,-8.5
+      parent: 2
+  - uid: 556
+    components:
+    - type: Transform
+      pos: -9.5,-9.5
+      parent: 2
+  - uid: 558
+    components:
+    - type: Transform
+      pos: -9.5,-11.5
+      parent: 2
+  - uid: 559
+    components:
+    - type: Transform
+      pos: -9.5,-12.5
+      parent: 2
+  - uid: 560
+    components:
+    - type: Transform
+      pos: -9.5,-13.5
+      parent: 2
+  - uid: 561
+    components:
+    - type: Transform
+      pos: -9.5,-14.5
+      parent: 2
+  - uid: 562
+    components:
+    - type: Transform
+      pos: -10.5,-14.5
+      parent: 2
+  - uid: 563
+    components:
+    - type: Transform
+      pos: -11.5,-14.5
+      parent: 2
+  - uid: 564
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 2
+  - uid: 565
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 2
+  - uid: 566
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 2
+  - uid: 567
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 2
+  - uid: 568
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 2
+  - uid: 569
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 2
+  - uid: 570
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 2
+  - uid: 571
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 2
+  - uid: 572
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 2
+  - uid: 573
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 2
+  - uid: 574
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 2
+  - uid: 575
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 2
+  - uid: 576
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 2
+  - uid: 577
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 2
+  - uid: 578
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 2
+  - uid: 579
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 2
+  - uid: 580
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 2
+  - uid: 581
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 2
+  - uid: 582
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 2
+  - uid: 583
+    components:
+    - type: Transform
+      pos: -5.5,-5.5
+      parent: 2
+  - uid: 584
+    components:
+    - type: Transform
+      pos: -6.5,-5.5
+      parent: 2
+  - uid: 585
+    components:
+    - type: Transform
+      pos: -6.5,-4.5
+      parent: 2
+  - uid: 586
+    components:
+    - type: Transform
+      pos: -6.5,-3.5
+      parent: 2
+  - uid: 587
+    components:
+    - type: Transform
+      pos: -6.5,-2.5
+      parent: 2
+  - uid: 588
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 2
+  - uid: 589
+    components:
+    - type: Transform
+      pos: -7.5,4.5
+      parent: 2
+  - uid: 590
+    components:
+    - type: Transform
+      pos: -7.5,5.5
+      parent: 2
+  - uid: 591
+    components:
+    - type: Transform
+      pos: -7.5,6.5
+      parent: 2
+  - uid: 592
+    components:
+    - type: Transform
+      pos: -7.5,7.5
+      parent: 2
+  - uid: 593
+    components:
+    - type: Transform
+      pos: -7.5,8.5
+      parent: 2
+  - uid: 595
+    components:
+    - type: Transform
+      pos: -6.5,9.5
+      parent: 2
+  - uid: 596
+    components:
+    - type: Transform
+      pos: -5.5,9.5
+      parent: 2
+  - uid: 597
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 2
+  - uid: 598
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 2
+  - uid: 599
+    components:
+    - type: Transform
+      pos: 7.5,6.5
+      parent: 2
+  - uid: 600
+    components:
+    - type: Transform
+      pos: 7.5,7.5
+      parent: 2
+  - uid: 601
+    components:
+    - type: Transform
+      pos: 7.5,8.5
+      parent: 2
+  - uid: 602
+    components:
+    - type: Transform
+      pos: 7.5,9.5
+      parent: 2
+  - uid: 603
+    components:
+    - type: Transform
+      pos: 6.5,9.5
+      parent: 2
+  - uid: 604
+    components:
+    - type: Transform
+      pos: 5.5,9.5
+      parent: 2
+  - uid: 1194
+    components:
+    - type: Transform
+      pos: -7.5,9.5
+      parent: 2
+- proto: CableMVStack1
+  entities:
+  - uid: 345
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.657139,-13.679013
+      parent: 2
+  - uid: 678
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.271722,-10.72068
+      parent: 2
+- proto: CableTerminal
+  entities:
+  - uid: 605
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-14.5
+      parent: 2
+  - uid: 606
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-15.5
+      parent: 2
+- proto: CargoPallet
+  entities:
+  - uid: 607
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-12.5
+      parent: 2
+  - uid: 608
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-13.5
+      parent: 2
+  - uid: 609
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-14.5
+      parent: 2
+  - uid: 610
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-12.5
+      parent: 2
+  - uid: 611
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-13.5
+      parent: 2
+  - uid: 612
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-14.5
+      parent: 2
+- proto: Catwalk
+  entities:
+  - uid: 613
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-10.5
+      parent: 2
+  - uid: 614
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-15.5
+      parent: 2
+  - uid: 615
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-14.5
+      parent: 2
+  - uid: 616
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-14.5
+      parent: 2
+  - uid: 617
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-15.5
+      parent: 2
+  - uid: 618
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-16.5
+      parent: 2
+  - uid: 619
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-16.5
+      parent: 2
+  - uid: 620
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-14.5
+      parent: 2
+  - uid: 621
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-15.5
+      parent: 2
+  - uid: 622
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-14.5
+      parent: 2
+  - uid: 623
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-15.5
+      parent: 2
+  - uid: 624
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-16.5
+      parent: 2
+  - uid: 625
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-16.5
+      parent: 2
+  - uid: 626
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-15.5
+      parent: 2
+  - uid: 627
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-14.5
+      parent: 2
+  - uid: 628
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-14.5
+      parent: 2
+  - uid: 629
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-15.5
+      parent: 2
+  - uid: 630
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-16.5
+      parent: 2
+  - uid: 631
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-16.5
+      parent: 2
+  - uid: 632
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-15.5
+      parent: 2
+  - uid: 633
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-14.5
+      parent: 2
+  - uid: 634
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-12.5
+      parent: 2
+  - uid: 635
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-11.5
+      parent: 2
+  - uid: 636
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,0.5
+      parent: 2
+  - uid: 637
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-9.5
+      parent: 2
+  - uid: 638
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-10.5
+      parent: 2
+  - uid: 639
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-11.5
+      parent: 2
+  - uid: 640
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-12.5
+      parent: 2
+  - uid: 641
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-12.5
+      parent: 2
+  - uid: 642
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-11.5
+      parent: 2
+  - uid: 643
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-10.5
+      parent: 2
+  - uid: 644
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,0.5
+      parent: 2
+  - uid: 645
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,0.5
+      parent: 2
+  - uid: 646
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-12.5
+      parent: 2
+  - uid: 647
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-11.5
+      parent: 2
+  - uid: 648
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-12.5
+      parent: 2
+  - uid: 649
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,0.5
+      parent: 2
+  - uid: 654
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-16.5
+      parent: 2
+  - uid: 655
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-16.5
+      parent: 2
+  - uid: 656
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-16.5
+      parent: 2
+  - uid: 657
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-16.5
+      parent: 2
+  - uid: 658
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-16.5
+      parent: 2
+- proto: ChairPilotSeat
+  entities:
+  - uid: 660
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,4.5
+      parent: 2
+  - uid: 661
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,0.5
+      parent: 2
+- proto: ClockworkGrille
+  entities:
+  - uid: 129
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,16.5
+      parent: 2
+  - uid: 133
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,16.5
+      parent: 2
+  - uid: 250
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,17.5
+      parent: 2
+  - uid: 401
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,16.5
+      parent: 2
+  - uid: 650
+    components:
+    - type: Transform
+      pos: 9.5,16.5
+      parent: 2
+  - uid: 652
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,17.5
+      parent: 2
+  - uid: 663
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,6.5
+      parent: 2
+  - uid: 664
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,6.5
+      parent: 2
+  - uid: 665
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,6.5
+      parent: 2
+  - uid: 666
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-4.5
+      parent: 2
+  - uid: 667
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-3.5
+      parent: 2
+  - uid: 668
+    components:
+    - type: Transform
+      pos: 9.5,-3.5
+      parent: 2
+  - uid: 669
+    components:
+    - type: Transform
+      pos: 9.5,-4.5
+      parent: 2
+  - uid: 684
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,17.5
+      parent: 2
+  - uid: 1006
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,16.5
+      parent: 2
+  - uid: 1105
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,17.5
+      parent: 2
+  - uid: 1141
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,17.5
+      parent: 2
+  - uid: 1169
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,17.5
+      parent: 2
+  - uid: 1172
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,15.5
+      parent: 2
+  - uid: 1184
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,17.5
+      parent: 2
+  - uid: 1185
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,16.5
+      parent: 2
+  - uid: 1188
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,16.5
+      parent: 2
+  - uid: 1193
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,15.5
+      parent: 2
+  - uid: 1204
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,15.5
+      parent: 2
+  - uid: 1206
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,16.5
+      parent: 2
+  - uid: 1207
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,17.5
+      parent: 2
+  - uid: 1607
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-22.5
+      parent: 2
+  - uid: 1692
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-21.5
+      parent: 2
+  - uid: 1693
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-21.5
+      parent: 2
+  - uid: 1694
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-21.5
+      parent: 2
+  - uid: 1695
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-21.5
+      parent: 2
+  - uid: 1696
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-22.5
+      parent: 2
+  - uid: 1697
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-22.5
+      parent: 2
+  - uid: 1698
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-22.5
+      parent: 2
+  - uid: 1700
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-22.5
+      parent: 2
+  - uid: 1701
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-22.5
+      parent: 2
+  - uid: 1702
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-22.5
+      parent: 2
+  - uid: 1703
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-22.5
+      parent: 2
+  - uid: 1704
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-22.5
+      parent: 2
+  - uid: 1705
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,-22.5
+      parent: 2
+  - uid: 1706
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,-21.5
+      parent: 2
+  - uid: 1707
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-21.5
+      parent: 2
+  - uid: 1708
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,-21.5
+      parent: 2
+  - uid: 1709
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,-21.5
+      parent: 2
+- proto: ClosetSteelBase
+  entities:
+  - uid: 670
+    components:
+    - type: Transform
+      pos: -9.5,-4.5
+      parent: 2
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 672
+          - 671
+          - 674
+          - 673
+          - 675
+          - 676
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: ClothingEyesBlindfold
+  entities:
+  - uid: 671
+    components:
+    - type: Transform
+      parent: 670
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 672
+    components:
+    - type: Transform
+      parent: 670
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ClothingMaskMuzzle
+  entities:
+  - uid: 673
+    components:
+    - type: Transform
+      parent: 670
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 674
+    components:
+    - type: Transform
+      parent: 670
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ClothingOuterHardsuitMercenary
+  entities:
+  - uid: 1264
+    components:
+    - type: Transform
+      pos: 8.490873,11.564101
+      parent: 2
+  - uid: 1731
+    components:
+    - type: Transform
+      pos: 9.459623,11.548476
+      parent: 2
+- proto: ClothingUniformJumpskirtPrisoner
+  entities:
+  - uid: 675
+    components:
+    - type: Transform
+      parent: 670
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ClothingUniformJumpskirtSec
+  entities:
+  - uid: 1768
+    components:
+    - type: MetaData
+      desc: То же самое что и боец но без прав.
+      name: комбинезон vitezstvi (боецка)
+    - type: Transform
+      parent: 1170
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ClothingUniformJumpsuitBrigmedic
+  entities:
+  - uid: 1766
+    components:
+    - type: MetaData
+      desc: От этой формы несет профессионализмом в пофигизме и запахом 95% спирта использованного не по назначению.
+      name: комбинезон vitezstvi (военный врач)
+    - type: Transform
+      parent: 1170
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ClothingUniformJumpsuitHoS
+  entities:
+  - uid: 1770
+    components:
+    - type: MetaData
+      desc: От этой формы несет немытыми подмышками и запахом напалма по утрам
+      name: комбинезон vitezstvi (командира отряда)
+    - type: Transform
+      parent: 1170
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ClothingUniformJumpsuitPrisoner
+  entities:
+  - uid: 676
+    components:
+    - type: Transform
+      parent: 670
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ClothingUniformJumpsuitSec
+  entities:
+  - uid: 1765
+    components:
+    - type: MetaData
+      desc: От этой формы несет 100% меткостью в спины товарищей. Враг у ворот!
+      name: комбинезон vitezstvi (боец)
+    - type: Transform
+      parent: 1170
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1767
+    components:
+    - type: MetaData
+      desc: От этой формы несет 100% меткостью в спины товарищей. Враг у ворот!
+      name: комбинезон vitezstvi (боец)
+    - type: Transform
+      parent: 1170
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1769
+    components:
+    - type: MetaData
+      desc: От этой формы несет 100% меткостью в спины товарищей. Враг у ворот!
+      name: комбинезон vitezstvi (боец)
+    - type: Transform
+      parent: 1170
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ClothingUniformJumpsuitSeniorOfficer
+  entities:
+  - uid: 1764
+    components:
+    - type: MetaData
+      desc: От этой формы несет пилотом, не советуем приближаться к ней ближе чем на 200 метров.
+      name: комбинезон vitezstvi (пилот)
+    - type: Transform
+      parent: 1170
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: Cobweb1
+  entities:
+  - uid: 680
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,10.5
+      parent: 2
+  - uid: 681
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,4.5
+      parent: 2
+  - uid: 682
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,6.5
+      parent: 2
+- proto: Cobweb2
+  entities:
+  - uid: 685
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,4.5
+      parent: 2
+  - uid: 686
+    components:
+    - type: Transform
+      pos: 12.5,5.5
+      parent: 2
+  - uid: 687
+    components:
+    - type: Transform
+      pos: 9.5,11.5
+      parent: 2
+- proto: ComputerBroken
+  entities:
+  - uid: 688
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,4.5
+      parent: 2
+- proto: ComputerPowerMonitoring
+  entities:
+  - uid: 132
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,11.5
+      parent: 2
+- proto: ComputerRadar
+  entities:
+  - uid: 691
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 2
+  - uid: 1177
+    components:
+    - type: Transform
+      pos: -5.5,12.5
+      parent: 2
+  - uid: 1714
+    components:
+    - type: Transform
+      pos: 6.5,12.5
+      parent: 2
+- proto: ComputerSalvageExpedition
+  entities:
+  - uid: 692
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,3.5
+      parent: 2
+- proto: ComputerShuttle
+  entities:
+  - uid: 693
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 2
+- proto: ComputerStationRecords
+  entities:
+  - uid: 694
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,3.5
+      parent: 2
+- proto: ConveyorBelt
+  entities:
+  - uid: 36
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,7.5
+      parent: 2
+  - uid: 407
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,10.5
+      parent: 2
+  - uid: 997
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,10.5
+      parent: 2
+  - uid: 1197
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,9.5
+      parent: 2
+  - uid: 1205
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,10.5
+      parent: 2
+  - uid: 1252
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,7.5
+      parent: 2
+  - uid: 1304
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,8.5
+      parent: 2
+- proto: CrateGenericSteel
+  entities:
+  - uid: 1715
+    components:
+    - type: Transform
+      pos: 10.5,-1.5
+      parent: 2
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14908
+        moles:
+        - 1.606311
+        - 6.042789
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 1720
+          - 1719
+          - 1718
+          - 1717
+          - 1716
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: CrateSecureMercenaryHardsuit
+  entities:
+  - uid: 1170
+    components:
+    - type: Transform
+      pos: 10.5,9.5
+      parent: 2
+    - type: Lock
+      locked: False
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14923
+        moles:
+        - 2.0253487
+        - 7.6191697
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 1768
+          - 1767
+          - 1765
+          - 1769
+          - 1766
+          - 1764
+          - 1770
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+    - type: Pullable
+      prevFixedRotation: True
+- proto: DefibrillatorCabinetFilled
+  entities:
+  - uid: 695
+    components:
+    - type: Transform
+      pos: -3.5,-11.5
+      parent: 2
+  - uid: 696
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-11.5
+      parent: 2
+- proto: DrinkBeerBottleFull
+  entities:
+  - uid: 1718
+    components:
+    - type: Transform
+      parent: 1715
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1719
+    components:
+    - type: Transform
+      parent: 1715
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1720
+    components:
+    - type: Transform
+      parent: 1715
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: DrinkBeerglass
+  entities:
+  - uid: 1716
+    components:
+    - type: Transform
+      parent: 1715
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1717
+    components:
+    - type: Transform
+      parent: 1715
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: DrinkKegWood
+  entities:
+  - uid: 701
+    components:
+    - type: Transform
+      pos: 11.548131,2.545815
+      parent: 2
+    - type: ItemSlots
+    - type: ContainerContainer
+      containers:
+        paper_label: !type:ContainerSlot {}
+- proto: DrinkVodkaBottleFull
+  entities:
+  - uid: 975
+    components:
+    - type: Transform
+      pos: 1.1986111,0.54011405
+      parent: 2
+  - uid: 979
+    components:
+    - type: Transform
+      pos: -0.49726582,4.898858
+      parent: 2
+- proto: EggSpider
+  entities:
+  - uid: 1171
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.485755,-16.436047
+      parent: 2
+  - uid: 1176
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.569089,-12.488131
+      parent: 2
+- proto: EmergencyLight
+  entities:
+  - uid: 702
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,0.5
+      parent: 2
+  - uid: 703
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,9.5
+      parent: 2
+  - uid: 704
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,0.5
+      parent: 2
+  - uid: 705
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,9.5
+      parent: 2
+  - uid: 706
+    components:
+    - type: Transform
+      pos: -5.5,12.5
+      parent: 2
+  - uid: 707
+    components:
+    - type: Transform
+      pos: 6.5,12.5
+      parent: 2
+  - uid: 708
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-16.5
+      parent: 2
+  - uid: 709
+    components:
+    - type: Transform
+      pos: 5.5,-11.5
+      parent: 2
+  - uid: 710
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,2.5
+      parent: 2
+  - uid: 711
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-10.5
+      parent: 2
+  - uid: 712
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-10.5
+      parent: 2
+  - uid: 713
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-9.5
+      parent: 2
+  - uid: 714
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-13.5
+      parent: 2
+  - uid: 715
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-9.5
+      parent: 2
+  - uid: 716
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-13.5
+      parent: 2
+  - uid: 717
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-14.5
+      parent: 2
+  - uid: 718
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-14.5
+      parent: 2
+  - uid: 719
+    components:
+    - type: Transform
+      pos: -6.5,-3.5
+      parent: 2
+  - uid: 720
+    components:
+    - type: Transform
+      pos: 7.5,-3.5
+      parent: 2
+  - uid: 721
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-7.5
+      parent: 2
+  - uid: 722
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-7.5
+      parent: 2
+  - uid: 723
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-8.5
+      parent: 2
+  - uid: 724
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-8.5
+      parent: 2
+- proto: FaxMachineShip
+  entities:
+  - uid: 980
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 2
+- proto: FireAxeCabinetOpen
+  entities:
+  - uid: 725
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-1.5
+      parent: 2
+- proto: Firelock
+  entities:
+  - uid: 726
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,0.5
+      parent: 2
+  - uid: 727
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-2.5
+      parent: 2
+  - uid: 728
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,-0.5
+      parent: 2
+  - uid: 729
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,1.5
+      parent: 2
+  - uid: 730
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,3.5
+      parent: 2
+  - uid: 731
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,0.5
+      parent: 2
+  - uid: 732
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-11.5
+      parent: 2
+  - uid: 733
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-11.5
+      parent: 2
+  - uid: 734
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-11.5
+      parent: 2
+  - uid: 735
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,3.5
+      parent: 2
+  - uid: 736
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-8.5
+      parent: 2
+  - uid: 737
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-8.5
+      parent: 2
+  - uid: 738
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-5.5
+      parent: 2
+  - uid: 739
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-2.5
+      parent: 2
+  - uid: 740
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,1.5
+      parent: 2
+  - uid: 741
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-0.5
+      parent: 2
+- proto: FirelockEdge
+  entities:
+  - uid: 742
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 2
+  - uid: 743
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 2
+  - uid: 744
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 2
+  - uid: 745
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-5.5
+      parent: 2
+  - uid: 746
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-6.5
+      parent: 2
+  - uid: 747
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-7.5
+      parent: 2
+  - uid: 748
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-8.5
+      parent: 2
+    - type: Door
+      secondsUntilStateChange: -21302.393
+      state: Closing
+  - uid: 749
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-9.5
+      parent: 2
+  - uid: 750
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-5.5
+      parent: 2
+  - uid: 751
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-6.5
+      parent: 2
+    - type: Door
+      secondsUntilStateChange: -22804.4
+      state: Closing
+  - uid: 752
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-7.5
+      parent: 2
+  - uid: 753
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-8.5
+      parent: 2
+  - uid: 754
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-9.5
+      parent: 2
+  - uid: 756
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-2.5
+      parent: 2
+  - uid: 757
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-2.5
+      parent: 2
+  - uid: 758
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-2.5
+      parent: 2
+- proto: FloorDrain
+  entities:
+  - uid: 759
+    components:
+    - type: Transform
+      pos: -8.5,-14.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+- proto: FoodBowlBig
+  entities:
+  - uid: 1722
+    components:
+    - type: Transform
+      pos: 1.4888316,-7.4656334
+      parent: 2
+  - uid: 1737
+    components:
+    - type: Transform
+      pos: -0.2554294,-8.372853
+      parent: 2
+  - uid: 1754
+    components:
+    - type: Transform
+      pos: 0.09994292,-6.3718834
+      parent: 2
+- proto: FoodMeatSpider
+  entities:
+  - uid: 1166
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.9617243,-13.734124
+      parent: 2
+  - uid: 1652
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.4825573,-14.411207
+      parent: 2
+  - uid: 1653
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.9304743,-12.71329
+      parent: 2
+- proto: GasPassiveVent
+  entities:
+  - uid: 760
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 761
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+- proto: GasPipeBend
+  entities:
+  - uid: 762
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 763
+    components:
+    - type: Transform
+      pos: 2.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 764
+    components:
+    - type: Transform
+      pos: 8.5,6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 765
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 766
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 767
+    components:
+    - type: Transform
+      pos: -8.5,8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 768
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 769
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 770
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 771
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-13.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 772
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 773
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-13.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 774
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 775
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 776
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 777
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+- proto: GasPipeFourway
+  entities:
+  - uid: 778
+    components:
+    - type: Transform
+      pos: 1.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 779
+    components:
+    - type: Transform
+      pos: -7.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 780
+    components:
+    - type: Transform
+      pos: 9.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 781
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+- proto: GasPipeStraight
+  entities:
+  - uid: 782
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 783
+    components:
+    - type: Transform
+      pos: -1.5,-15.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 784
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 785
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 786
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-15.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 787
+    components:
+    - type: Transform
+      pos: -8.5,7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 788
+    components:
+    - type: Transform
+      pos: -8.5,6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 789
+    components:
+    - type: Transform
+      pos: -8.5,5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 790
+    components:
+    - type: Transform
+      pos: -8.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 791
+    components:
+    - type: Transform
+      pos: -8.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 792
+    components:
+    - type: Transform
+      pos: -8.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 793
+    components:
+    - type: Transform
+      pos: -8.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 794
+    components:
+    - type: Transform
+      pos: -7.5,5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 795
+    components:
+    - type: Transform
+      pos: -7.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 796
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 797
+    components:
+    - type: Transform
+      pos: -7.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 798
+    components:
+    - type: Transform
+      pos: -7.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 799
+    components:
+    - type: Transform
+      pos: -7.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 800
+    components:
+    - type: Transform
+      pos: -8.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 801
+    components:
+    - type: Transform
+      pos: -8.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 802
+    components:
+    - type: Transform
+      pos: -8.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 803
+    components:
+    - type: Transform
+      pos: -8.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 804
+    components:
+    - type: Transform
+      pos: -8.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 805
+    components:
+    - type: Transform
+      pos: -8.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 806
+    components:
+    - type: Transform
+      pos: -8.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 807
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-11.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 808
+    components:
+    - type: Transform
+      pos: -7.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 809
+    components:
+    - type: Transform
+      pos: -7.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 810
+    components:
+    - type: Transform
+      pos: -7.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 811
+    components:
+    - type: Transform
+      pos: -7.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 812
+    components:
+    - type: Transform
+      pos: -7.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 813
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 814
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 815
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 816
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 817
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 818
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 819
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 820
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 821
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 822
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 823
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 824
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 825
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 826
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 827
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 828
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 829
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 830
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 831
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 832
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 833
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 834
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 835
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 836
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 837
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 838
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 839
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 840
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 841
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 842
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 843
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 844
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 845
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 846
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 847
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 848
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 849
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 850
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 851
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 852
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 853
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 854
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 855
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 856
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 857
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 858
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 859
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 860
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 861
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 862
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 863
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 864
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 865
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 866
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 867
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 868
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 869
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 870
+    components:
+    - type: Transform
+      pos: 10.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 871
+    components:
+    - type: Transform
+      pos: 10.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 872
+    components:
+    - type: Transform
+      pos: 11.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 873
+    components:
+    - type: Transform
+      pos: 11.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 874
+    components:
+    - type: Transform
+      pos: 11.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 875
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 876
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 877
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 878
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 879
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 880
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-13.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 881
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-13.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 882
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 883
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 884
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 885
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 886
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-11.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 887
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 888
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 889
+    components:
+    - type: Transform
+      pos: -0.5,-10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 890
+    components:
+    - type: Transform
+      pos: -0.5,-11.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 891
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 892
+    components:
+    - type: Transform
+      pos: 1.5,-8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 893
+    components:
+    - type: Transform
+      pos: 1.5,-9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 894
+    components:
+    - type: Transform
+      pos: 1.5,-10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 895
+    components:
+    - type: Transform
+      pos: 1.5,-11.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 896
+    components:
+    - type: Transform
+      pos: 1.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 897
+    components:
+    - type: Transform
+      pos: -7.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 898
+    components:
+    - type: Transform
+      pos: -7.5,-8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 899
+    components:
+    - type: Transform
+      pos: -7.5,-9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 900
+    components:
+    - type: Transform
+      pos: -7.5,-10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 901
+    components:
+    - type: Transform
+      pos: -7.5,-11.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 902
+    components:
+    - type: Transform
+      pos: -9.5,-13.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 903
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 904
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 905
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 906
+    components:
+    - type: Transform
+      pos: -6.5,-13.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 907
+    components:
+    - type: Transform
+      pos: -6.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 908
+    components:
+    - type: Transform
+      pos: -6.5,-11.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 909
+    components:
+    - type: Transform
+      pos: -6.5,-10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 910
+    components:
+    - type: Transform
+      pos: -6.5,-9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 911
+    components:
+    - type: Transform
+      pos: -6.5,-8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 912
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 913
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 914
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 915
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 916
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 917
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 918
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 919
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 920
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 921
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 922
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 923
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+- proto: GasPipeTJunction
+  entities:
+  - uid: 924
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 925
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 926
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 927
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 928
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 929
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 930
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 931
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 932
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 933
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 934
+    components:
+    - type: Transform
+      pos: -5.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 935
+    components:
+    - type: Transform
+      pos: 6.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 936
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 937
+    components:
+    - type: Transform
+      pos: -6.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 938
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 939
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 940
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 941
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 942
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+- proto: GasPort
+  entities:
+  - uid: 943
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-13.5
+      parent: 2
+- proto: GasPressurePump
+  entities:
+  - uid: 944
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-13.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+- proto: GasValve
+  entities:
+  - uid: 945
+    components:
+    - type: Transform
+      pos: -0.5,-13.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+- proto: GasVentPump
+  entities:
+  - uid: 946
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-13.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 947
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-12.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 6
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 948
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 949
+    components:
+    - type: Transform
+      pos: -11.5,-3.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 6
+      - 7
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 950
+    components:
+    - type: Transform
+      pos: 10.5,-3.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 5
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 951
+    components:
+    - type: Transform
+      pos: -6.5,-5.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 7
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 952
+    components:
+    - type: Transform
+      pos: 7.5,-5.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 5
+      - 7
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 953
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+      - 7
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 954
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+      - 7
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 955
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-0.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 9
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 956
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-0.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 10
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 957
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,6.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 8
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 958
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,6.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 11
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 959
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-13.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 5
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+- proto: GasVentScrubber
+  entities:
+  - uid: 960
+    components:
+    - type: Transform
+      pos: -9.5,-3.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 6
+      - 7
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 961
+    components:
+    - type: Transform
+      pos: 11.5,-3.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 5
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 962
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-8.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 7
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 963
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-8.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 5
+      - 7
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 964
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-10.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+      - 7
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 965
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+      - 7
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 966
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,8.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 8
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 967
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,8.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 11
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 968
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,0.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 9
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 969
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,0.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 10
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 970
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-13.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 5
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 971
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-12.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 972
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 973
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-14.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 6
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 974
+    components:
+    - type: Transform
+      pos: 7.5,-16.5
+      parent: 2
+- proto: Grille
+  entities:
+  - uid: 988
+    components:
+    - type: Transform
+      pos: 9.5,16.5
+      parent: 2
+  - uid: 1007
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,17.5
+      parent: 2
+  - uid: 1190
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,16.5
+      parent: 2
+  - uid: 1191
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,17.5
+      parent: 2
+  - uid: 1195
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,17.5
+      parent: 2
+  - uid: 1198
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,17.5
+      parent: 2
+  - uid: 1199
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,16.5
+      parent: 2
+  - uid: 1200
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,16.5
+      parent: 2
+  - uid: 1201
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,16.5
+      parent: 2
+  - uid: 1202
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,16.5
+      parent: 2
+  - uid: 1203
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,17.5
+      parent: 2
+  - uid: 1360
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,17.5
+      parent: 2
+  - uid: 1578
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,15.5
+      parent: 2
+  - uid: 1699
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-22.5
+      parent: 2
+  - uid: 1710
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,-21.5
+      parent: 2
+  - uid: 1711
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-21.5
+      parent: 2
+  - uid: 1712
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,-21.5
+      parent: 2
+  - uid: 1763
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-22.5
+      parent: 2
+  - uid: 1771
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-22.5
+      parent: 2
+  - uid: 1772
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-22.5
+      parent: 2
+  - uid: 1773
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-22.5
+      parent: 2
+  - uid: 1774
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-22.5
+      parent: 2
+  - uid: 1775
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-21.5
+      parent: 2
+  - uid: 1776
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-21.5
+      parent: 2
+  - uid: 1778
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-21.5
+      parent: 2
+- proto: GrilleDiagonal
+  entities:
+  - uid: 594
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,16.5
+      parent: 2
+  - uid: 1067
+    components:
+    - type: Transform
+      pos: -8.5,17.5
+      parent: 2
+  - uid: 1151
+    components:
+    - type: Transform
+      pos: -11.5,16.5
+      parent: 2
+  - uid: 1187
+    components:
+    - type: Transform
+      pos: -0.5,15.5
+      parent: 2
+  - uid: 1240
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,17.5
+      parent: 2
+  - uid: 1658
+    components:
+    - type: Transform
+      pos: 5.5,17.5
+      parent: 2
+  - uid: 1660
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,17.5
+      parent: 2
+  - uid: 1661
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,15.5
+      parent: 2
+  - uid: 1782
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-21.5
+      parent: 2
+  - uid: 1783
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-22.5
+      parent: 2
+  - uid: 1784
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-22.5
+      parent: 2
+  - uid: 1785
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-22.5
+      parent: 2
+  - uid: 1786
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-22.5
+      parent: 2
+  - uid: 1787
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-21.5
+      parent: 2
+- proto: GunSafe
+  entities:
+  - uid: 987
+    components:
+    - type: Transform
+      anchored: True
+      pos: 10.5,10.5
+      parent: 2
+    - type: Physics
+      bodyType: Static
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14914
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 1667
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+    - type: Pullable
+      prevFixedRotation: True
+  - uid: 1745
+    components:
+    - type: Transform
+      pos: 6.5,6.5
+      parent: 2
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14908
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+- proto: Gyroscope
+  entities:
+  - uid: 689
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 2
+  - uid: 977
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 2
+  - uid: 978
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 2
+  - uid: 1777
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 2
+- proto: HandHeldMassScanner
+  entities:
+  - uid: 1070
+    components:
+    - type: Transform
+      parent: 1069
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1134
+    components:
+    - type: Transform
+      parent: 1131
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: KitchenMicrowave
+  entities:
+  - uid: 1629
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 2
+- proto: KukriKnife
+  entities:
+  - uid: 981
+    components:
+    - type: Transform
+      pos: 11.498602,7.6255636
+      parent: 2
+- proto: LockerEngineerFilledHardsuit
+  entities:
+  - uid: 984
+    components:
+    - type: Transform
+      pos: 5.5,-11.5
+      parent: 2
+- proto: LockerMercenary
+  entities:
+  - uid: 1069
+    components:
+    - type: Transform
+      pos: 6.5,8.5
+      parent: 2
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14923
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 1070
+          - 1121
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+  - uid: 1131
+    components:
+    - type: Transform
+      pos: 6.5,7.5
+      parent: 2
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14923
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 1134
+          - 1148
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: LockerParamedicFilledHardsuit
+  entities:
+  - uid: 198
+    components:
+    - type: Transform
+      pos: -7.5,-16.5
+      parent: 2
+- proto: LockerSalvageSpecialistFilledHardsuit
+  entities:
+  - uid: 1638
+    components:
+    - type: Transform
+      pos: 2.5,-12.5
+      parent: 2
+- proto: MachineFlatpacker
+  entities:
+  - uid: 137
+    components:
+    - type: Transform
+      pos: -5.5,6.5
+      parent: 2
+- proto: MachineFrame
+  entities:
+  - uid: 193
+    components:
+    - type: Transform
+      pos: -9.5,7.5
+      parent: 2
+- proto: MachineFrameDestroyed
+  entities:
+  - uid: 1000
+    components:
+    - type: Transform
+      pos: 6.5,-10.5
+      parent: 2
+- proto: Mattress
+  entities:
+  - uid: 1001
+    components:
+    - type: Transform
+      pos: -9.5,-3.5
+      parent: 2
+  - uid: 1002
+    components:
+    - type: Transform
+      pos: -11.5,-3.5
+      parent: 2
+- proto: MedicalBed
+  entities:
+  - uid: 1004
+    components:
+    - type: Transform
+      pos: -5.5,-10.5
+      parent: 2
+  - uid: 1157
+    components:
+    - type: Transform
+      pos: -4.5,-16.5
+      parent: 2
+  - uid: 1162
+    components:
+    - type: Transform
+      pos: -6.5,-16.5
+      parent: 2
+  - uid: 1728
+    components:
+    - type: Transform
+      pos: -7.5,-10.5
+      parent: 2
+- proto: MedkitCombatFilled
+  entities:
+  - uid: 1196
+    components:
+    - type: Transform
+      pos: -6.4757924,-10.49695
+      parent: 2
+- proto: MercenaryTechFab
+  entities:
+  - uid: 998
+    components:
+    - type: Transform
+      pos: -9.5,4.5
+      parent: 2
+- proto: OreProcessor
+  entities:
+  - uid: 1005
+    components:
+    - type: Transform
+      pos: -1.5,-14.5
+      parent: 2
+- proto: OxygenTankFilled
+  entities:
+  - uid: 1733
+    components:
+    - type: Transform
+      pos: 9.450583,11.618082
+      parent: 2
+  - uid: 1738
+    components:
+    - type: Transform
+      pos: 8.528708,11.571207
+      parent: 2
+- proto: Paper
+  entities:
+  - uid: 1
+    components:
+    - type: Transform
+      pos: -0.14732742,4.4116244
+      parent: 2
+    - type: Paper
+      stampState: paper_stamp-centcom
+      stampedBy:
+      - reapply: False
+        stampType: RubberStamp
+        stampedColor: '#006600FF'
+        stampedName: stamp-component-stamped-name-centcom
+      - reapply: True
+        stampType: RubberStamp
+        stampedColor: '#00BE00FF'
+        stampedName: stamp-component-stamped-name-approved
+      - reapply: False
+        stampType: RubberStamp
+        stampedColor: '#5E1010FF'
+        stampedName: Vitezstvi
+      content: >-
+        [color=#1b487e]███░███░░░░██░░░░[/color]
+
+        [color=#1b487e]░██░████░░░██░░░░[/color]      [head=3]Бланк документа[/head]
+
+        [color=#1b487e]░░█░██░██░░██░█░░[/color]               [head=3]NanoTrasen[/head]
+
+        [color=#1b487e]░░░░██░░██░██░██░[/color] [bold]Сектор Фронтиры [/bold]
+
+        [color=#1b487e]░░░░██░░░████░███[/color]
+
+        =============================================
+                          РАЗРЕШЕНИЕ НА ИСПОЛЬЗОВАНИЕ ОРУДИЯ
+        =============================================
+
+
+
+        При покупке шаттла VT-A (Vitezstvi Technology - Assault) Заря, предоставляется корабельные орудия Trophy-50 и NVT-35 для использования самообороны от враждебных угроз (враждебные шаттлы или неопознанные объекты, объявленными Центральным Командованием, Службы безопасности или представителем Фронтиры) и опасной фауны.
+
+        Департамента Службы Безопасности Фронтиры (ДСБФ) имеют право уничтожить орудия в случаи доказательства использования орудия в корыстных целях:
+
+        - Чрезмерное использования орудия в открытом космосе
+
+        - Использования орудия против гражданских, ДСБФ и различных пилотируемых шаттлов, а так же различных сооружений, которые считаются безопасными.
+
+        Если было замечено нарушения - ДСБФ обязан вас арестовать до конца расследования и вынесения приговора.
+
+        =============================================
+                                    [italic]Место для печатей[/italic]
+- proto: PinpointerUniversal
+  entities:
+  - uid: 1121
+    components:
+    - type: Transform
+      parent: 1069
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1148
+    components:
+    - type: Transform
+      parent: 1131
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1265
+    components:
+    - type: Transform
+      pos: 8.546928,11.567528
+      parent: 2
+  - uid: 1730
+    components:
+    - type: Transform
+      pos: 9.497397,11.580221
+      parent: 2
+- proto: PlastitaniumWindow
+  entities:
+  - uid: 1014
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 2
+  - uid: 1015
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 2
+  - uid: 1016
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 2
+  - uid: 1017
+    components:
+    - type: Transform
+      pos: 9.5,-3.5
+      parent: 2
+  - uid: 1160
+    components:
+    - type: Transform
+      pos: -8.5,-4.5
+      parent: 2
+  - uid: 1266
+    components:
+    - type: Transform
+      pos: 9.5,-4.5
+      parent: 2
+  - uid: 1646
+    components:
+    - type: Transform
+      pos: -8.5,-3.5
+      parent: 2
+- proto: PlushieDeer
+  entities:
+  - uid: 1247
+    components:
+    - type: MetaData
+      desc: Очаровательная мягкая игрушка, напоминающая оленя!                                                                                                               Оно имеет сикей "dimonsupe".
+    - type: Transform
+      pos: -1.5197711,-8.480786
+      parent: 2
+- proto: PlushieLoveable
+  entities:
+  - uid: 1723
+    components:
+    - type: MetaData
+      desc: Очаровательная мягкая игрушка, напоминающая... существо.                                                                                                                  Оно имеет сикей "mersen".
+    - type: Transform
+      pos: 2.5264137,-7.4912033
+      parent: 2
+- proto: PlushieOrangeFox
+  entities:
+  - uid: 1242
+    components:
+    - type: MetaData
+      desc: Очаровательная мягкая игрушка, напоминающая лису!                                                                                                       Оно имеет сикей "Terka".
+    - type: Transform
+      pos: 1.5194693,-5.4946756
+      parent: 2
+- proto: PosterBroken
+  entities:
+  - uid: 1019
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,2.5
+      parent: 2
+- proto: PosterContrabandBustyBackdoorExoBabes6
+  entities:
+  - uid: 1020
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,12.5
+      parent: 2
+  - uid: 1021
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,3.5
+      parent: 2
+- proto: PosterContrabandEnlistGorlex
+  entities:
+  - uid: 1022
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-17.5
+      parent: 2
+- proto: PosterContrabandLustyExomorph
+  entities:
+  - uid: 1023
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-2.5
+      parent: 2
+- proto: PosterLegitShoukou
+  entities:
+  - uid: 1024
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-4.5
+      parent: 2
+- proto: PowerCellRecharger
+  entities:
+  - uid: 1729
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 2
+- proto: Poweredlight
+  entities:
+  - uid: 1026
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-13.5
+      parent: 2
+  - uid: 1027
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-13.5
+      parent: 2
+  - uid: 1028
+    components:
+    - type: Transform
+      pos: -10.5,-3.5
+      parent: 2
+  - uid: 1029
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,1.5
+      parent: 2
+  - uid: 1030
+    components:
+    - type: Transform
+      pos: -12.5,-0.5
+      parent: 2
+  - uid: 1031
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-1.5
+      parent: 2
+  - uid: 1032
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-1.5
+      parent: 2
+  - uid: 1033
+    components:
+    - type: Transform
+      pos: 13.5,-0.5
+      parent: 2
+  - uid: 1034
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,1.5
+      parent: 2
+  - uid: 1035
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,3.5
+      parent: 2
+  - uid: 1036
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,3.5
+      parent: 2
+  - uid: 1037
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-1.5
+      parent: 2
+  - uid: 1038
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-1.5
+      parent: 2
+- proto: PoweredlightLED
+  entities:
+  - uid: 651
+    components:
+    - type: Transform
+      anchored: False
+      rot: -1.5707963267948966 rad
+      pos: 3.5,10.5
+      parent: 2
+  - uid: 1039
+    components:
+    - type: Transform
+      pos: -1.5,-16.5
+      parent: 2
+  - uid: 1040
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,-1.5
+      parent: 2
+  - uid: 1041
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-14.5
+      parent: 2
+  - uid: 1042
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-10.5
+      parent: 2
+  - uid: 1043
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-15.5
+      parent: 2
+  - uid: 1044
+    components:
+    - type: Transform
+      pos: -5.5,-10.5
+      parent: 2
+  - uid: 1045
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-12.5
+      parent: 2
+  - uid: 1046
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-13.5
+      parent: 2
+  - uid: 1047
+    components:
+    - type: Transform
+      pos: 6.5,-10.5
+      parent: 2
+  - uid: 1048
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-16.5
+      parent: 2
+  - uid: 1049
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 2
+  - uid: 1051
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-10.5
+      parent: 2
+  - uid: 1052
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-10.5
+      parent: 2
+  - uid: 1053
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-7.5
+      parent: 2
+  - uid: 1054
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-7.5
+      parent: 2
+  - uid: 1055
+    components:
+    - type: Transform
+      pos: 2.5,-16.5
+      parent: 2
+  - uid: 1056
+    components:
+    - type: Transform
+      pos: -8.5,2.5
+      parent: 2
+  - uid: 1057
+    components:
+    - type: Transform
+      pos: 9.5,2.5
+      parent: 2
+  - uid: 1058
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-1.5
+      parent: 2
+  - uid: 1059
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,7.5
+      parent: 2
+  - uid: 1060
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,6.5
+      parent: 2
+  - uid: 1061
+    components:
+    - type: Transform
+      pos: -7.5,11.5
+      parent: 2
+  - uid: 1062
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,8.5
+      parent: 2
+  - uid: 1063
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,8.5
+      parent: 2
+  - uid: 1064
+    components:
+    - type: Transform
+      pos: 8.5,11.5
+      parent: 2
+  - uid: 1065
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,6.5
+      parent: 2
+  - uid: 1066
+    components:
+    - type: Transform
+      anchored: False
+      rot: 1.5707963267948966 rad
+      pos: -2.5,10.5
+      parent: 2
+  - uid: 1756
+    components:
+    - type: Transform
+      pos: 4.5,-5.5
+      parent: 2
+- proto: PoweredlightPink
+  entities:
+  - uid: 1068
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-4.5
+      parent: 2
+- proto: Protolathe
+  entities:
+  - uid: 196
+    components:
+    - type: Transform
+      pos: -9.5,9.5
+      parent: 2
+- proto: Rack
+  entities:
+  - uid: 1025
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,5.5
+      parent: 2
+  - uid: 1071
+    components:
+    - type: Transform
+      pos: -9.5,0.5
+      parent: 2
+  - uid: 1072
+    components:
+    - type: Transform
+      pos: -10.5,0.5
+      parent: 2
+  - uid: 1075
+    components:
+    - type: Transform
+      pos: 7.5,-12.5
+      parent: 2
+  - uid: 1076
+    components:
+    - type: Transform
+      pos: 8.5,-12.5
+      parent: 2
+  - uid: 1077
+    components:
+    - type: Transform
+      pos: 9.5,-12.5
+      parent: 2
+  - uid: 1311
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,4.5
+      parent: 2
+  - uid: 1626
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,4.5
+      parent: 2
+  - uid: 1645
+    components:
+    - type: Transform
+      pos: 10.5,0.5
+      parent: 2
+  - uid: 1647
+    components:
+    - type: Transform
+      pos: 11.5,0.5
+      parent: 2
+  - uid: 1724
+    components:
+    - type: Transform
+      pos: 9.5,11.5
+      parent: 2
+  - uid: 1725
+    components:
+    - type: Transform
+      pos: 8.5,11.5
+      parent: 2
+  - uid: 1726
+    components:
+    - type: Transform
+      pos: 10.5,4.5
+      parent: 2
+  - uid: 1727
+    components:
+    - type: Transform
+      pos: 9.5,4.5
+      parent: 2
+- proto: RadioHandheldNF
+  entities:
+  - uid: 1631
+    components:
+    - type: Transform
+      pos: 9.433987,11.488253
+      parent: 2
+  - uid: 1641
+    components:
+    - type: Transform
+      pos: 8.635376,11.522975
+      parent: 2
+- proto: Railing
+  entities:
+  - uid: 1078
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-3.5
+      parent: 2
+  - uid: 1079
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-3.5
+      parent: 2
+  - uid: 1761
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-10.5
+      parent: 2
+- proto: RailingCorner
+  entities:
+  - uid: 408
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,12.5
+      parent: 2
+  - uid: 557
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,12.5
+      parent: 2
+  - uid: 677
+    components:
+    - type: Transform
+      pos: 5.5,12.5
+      parent: 2
+  - uid: 679
+    components:
+    - type: Transform
+      pos: -6.5,12.5
+      parent: 2
+  - uid: 1180
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,10.5
+      parent: 2
+  - uid: 1181
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,8.5
+      parent: 2
+  - uid: 1762
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,10.5
+      parent: 2
+- proto: RandomInstruments
+  entities:
+  - uid: 1779
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 2
+- proto: RandomPosterAny
+  entities:
+  - uid: 1080
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-9.5
+      parent: 2
+  - uid: 1081
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-13.5
+      parent: 2
+  - uid: 1082
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-10.5
+      parent: 2
+  - uid: 1083
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-4.5
+      parent: 2
+  - uid: 1084
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,2.5
+      parent: 2
+  - uid: 1085
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,3.5
+      parent: 2
+  - uid: 1086
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,7.5
+      parent: 2
+  - uid: 1087
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,12.5
+      parent: 2
+  - uid: 1088
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,7.5
+      parent: 2
+  - uid: 1089
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-12.5
+      parent: 2
+  - uid: 1090
+    components:
+    - type: Transform
+      pos: -11.5,-6.5
+      parent: 2
+- proto: RandomPosterContrabandDeadDrop
+  entities:
+  - uid: 1780
+    components:
+    - type: Transform
+      pos: -3.5,-17.5
+      parent: 2
+- proto: RandomSpawner
+  entities:
+  - uid: 1091
+    components:
+    - type: Transform
+      pos: -5.5,-13.5
+      parent: 2
+  - uid: 1092
+    components:
+    - type: Transform
+      pos: -10.5,-6.5
+      parent: 2
+  - uid: 1093
+    components:
+    - type: Transform
+      pos: -9.5,-15.5
+      parent: 2
+  - uid: 1094
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 2
+  - uid: 1095
+    components:
+    - type: Transform
+      pos: -5.5,-4.5
+      parent: 2
+  - uid: 1096
+    components:
+    - type: Transform
+      pos: -9.5,-1.5
+      parent: 2
+  - uid: 1097
+    components:
+    - type: Transform
+      pos: -7.5,0.5
+      parent: 2
+  - uid: 1098
+    components:
+    - type: Transform
+      pos: -9.5,2.5
+      parent: 2
+  - uid: 1099
+    components:
+    - type: Transform
+      pos: -7.5,5.5
+      parent: 2
+  - uid: 1101
+    components:
+    - type: Transform
+      pos: -6.5,8.5
+      parent: 2
+  - uid: 1102
+    components:
+    - type: Transform
+      pos: 6.5,9.5
+      parent: 2
+  - uid: 1103
+    components:
+    - type: Transform
+      pos: 9.5,10.5
+      parent: 2
+  - uid: 1104
+    components:
+    - type: Transform
+      pos: 10.5,8.5
+      parent: 2
+  - uid: 1106
+    components:
+    - type: Transform
+      pos: 10.5,-0.5
+      parent: 2
+  - uid: 1107
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 2
+  - uid: 1108
+    components:
+    - type: Transform
+      pos: 8.5,-5.5
+      parent: 2
+  - uid: 1109
+    components:
+    - type: Transform
+      pos: 6.5,-8.5
+      parent: 2
+  - uid: 1110
+    components:
+    - type: Transform
+      pos: 3.5,-6.5
+      parent: 2
+  - uid: 1111
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 2
+  - uid: 1112
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 2
+  - uid: 1113
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 2
+  - uid: 1114
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 2
+  - uid: 1115
+    components:
+    - type: Transform
+      pos: -0.5,-14.5
+      parent: 2
+  - uid: 1116
+    components:
+    - type: Transform
+      pos: -1.5,-14.5
+      parent: 2
+  - uid: 1117
+    components:
+    - type: Transform
+      pos: -1.5,-13.5
+      parent: 2
+  - uid: 1118
+    components:
+    - type: Transform
+      pos: 6.5,-15.5
+      parent: 2
+  - uid: 1119
+    components:
+    - type: Transform
+      pos: 10.5,-13.5
+      parent: 2
+  - uid: 1120
+    components:
+    - type: Transform
+      pos: 6.5,-11.5
+      parent: 2
+- proto: SheetPaper
+  entities:
+  - uid: 1689
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5079045,7.671258
+      parent: 2
+- proto: SheetPlasteel10
+  entities:
+  - uid: 1123
+    components:
+    - type: Transform
+      pos: 9.280281,-12.362426
+      parent: 2
+  - uid: 1124
+    components:
+    - type: Transform
+      pos: 9.530281,-12.409333
+      parent: 2
+  - uid: 1125
+    components:
+    - type: Transform
+      pos: 9.655281,-12.409333
+      parent: 2
+- proto: SheetSteel10
+  entities:
+  - uid: 1126
+    components:
+    - type: Transform
+      pos: 8.249031,-12.362426
+      parent: 2
+  - uid: 1127
+    components:
+    - type: Transform
+      pos: 8.436531,-12.37806
+      parent: 2
+  - uid: 1128
+    components:
+    - type: Transform
+      pos: 8.608406,-12.37806
+      parent: 2
+- proto: ShuttleShotgun
+  entities:
+  - uid: 1585
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,12.5
+      parent: 2
+    - type: ContainerContainer
+      containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        gun_magazine: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 1589
+    missingComponents:
+    - Anchorable
+    - Construction
+  - uid: 1663
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,12.5
+      parent: 2
+    - type: ContainerContainer
+      containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        gun_magazine: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 1664
+    missingComponents:
+    - Anchorable
+    - Construction
+- proto: ShuttleShotgunShellsBox
+  entities:
+  - uid: 1589
+    components:
+    - type: Transform
+      parent: 1585
+    - type: Physics
+      canCollide: False
+  - uid: 1664
+    components:
+    - type: Transform
+      parent: 1663
+    - type: Physics
+      canCollide: False
+- proto: ShuttleSMGRifle
+  entities:
+  - uid: 197
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,10.5
+      parent: 2
+    - type: ContainerContainer
+      containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        ballistic-ammo: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        gun_magazine: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+    missingComponents:
+    - Anchorable
+    - Construction
+- proto: SignalButton
+  entities:
+  - uid: 1129
+    components:
+    - type: Transform
+      pos: -9.5,-5.5
+      parent: 2
+  - uid: 1130
+    components:
+    - type: MetaData
+      name: Затвор
+    - type: Transform
+      pos: -5.5,12.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        199:
+        - Pressed: Toggle
+  - uid: 1132
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,0.5
+      parent: 2
+    - type: SignalSwitch
+      state: True
+    - type: DeviceLinkSource
+      linkedPorts:
+        205:
+        - Pressed: Toggle
+        204:
+        - Pressed: Toggle
+  - uid: 1133
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,0.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        206:
+        - Pressed: Toggle
+        207:
+        - Pressed: Toggle
+  - uid: 1309
+    components:
+    - type: Transform
+      pos: 6.5,12.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        203:
+        - Pressed: Toggle
+- proto: SignalSwitch
+  entities:
+  - uid: 982
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 2
+  - uid: 983
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        1612:
+        - Off: Close
+        1585:
+        - Off: Off
+        409:
+        - On: Trigger
+        1663:
+        - Off: Off
+        1237:
+        - Off: Close
+- proto: SignalTimer
+  entities:
+  - uid: 409
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        1237:
+        - Start: Open
+        1612:
+        - Start: Open
+        1663:
+        - Timer: On
+        1585:
+        - Timer: On
+- proto: SignBridge
+  entities:
+  - uid: 1135
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-3.5
+      parent: 2
+  - uid: 1136
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-3.5
+      parent: 2
+- proto: SignCargoDock
+  entities:
+  - uid: 1137
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-11.5
+      parent: 2
+- proto: SignEngineering
+  entities:
+  - uid: 1138
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-8.5
+      parent: 2
+- proto: SignMedical
+  entities:
+  - uid: 1139
+    components:
+    - type: Transform
+      pos: -8.5,-8.5
+      parent: 2
+- proto: SignMinerDock
+  entities:
+  - uid: 1140
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-11.5
+      parent: 2
+- proto: SignSecure
+  entities:
+  - uid: 1142
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,3.5
+      parent: 2
+- proto: SignSecurity
+  entities:
+  - uid: 1143
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,3.5
+      parent: 2
+- proto: SignSmoking
+  entities:
+  - uid: 1144
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,3.5
+      parent: 2
+- proto: SinkWide
+  entities:
+  - uid: 1145
+    components:
+    - type: Transform
+      pos: 10.5,-3.5
+      parent: 2
+  - uid: 1755
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 2
+- proto: SMESBasic
+  entities:
+  - uid: 1146
+    components:
+    - type: Transform
+      pos: 4.5,-14.5
+      parent: 2
+  - uid: 1147
+    components:
+    - type: Transform
+      pos: 4.5,-15.5
+      parent: 2
+- proto: SpawnDungeonLootMugs
+  entities:
+  - uid: 995
+    components:
+    - type: Transform
+      pos: 1.4210275,-6.4261494
+      parent: 2
+  - uid: 996
+    components:
+    - type: Transform
+      pos: -0.53209746,-6.9105244
+      parent: 2
+  - uid: 1263
+    components:
+    - type: Transform
+      pos: 1.2099483,-8.238566
+      parent: 2
+- proto: SpawnDungeonLootPowerCell
+  entities:
+  - uid: 1644
+    components:
+    - type: Transform
+      pos: -0.40817523,5.591854
+      parent: 2
+- proto: SpawnMobSpaceCobra
+  entities:
+  - uid: 1239
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-14.5
+      parent: 2
+- proto: SpawnMobSpaceSpider
+  entities:
+  - uid: 991
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-12.5
+      parent: 2
+  - uid: 1759
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-15.5
+      parent: 2
+- proto: SpawnPointLatejoin
+  entities:
+  - uid: 1153
+    components:
+    - type: Transform
+      pos: -0.5,-9.5
+      parent: 2
+  - uid: 1154
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 2
+  - uid: 1155
+    components:
+    - type: Transform
+      pos: 1.5,-9.5
+      parent: 2
+  - uid: 1156
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 2
+- proto: SpiderWeb
+  entities:
+  - uid: 690
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-11.5
+      parent: 2
+  - uid: 990
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-7.5
+      parent: 2
+  - uid: 992
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-14.5
+      parent: 2
+  - uid: 993
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-15.5
+      parent: 2
+  - uid: 1008
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-12.5
+      parent: 2
+  - uid: 1009
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-11.5
+      parent: 2
+  - uid: 1012
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-11.5
+      parent: 2
+  - uid: 1013
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-15.5
+      parent: 2
+  - uid: 1122
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-12.5
+      parent: 2
+  - uid: 1164
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-11.5
+      parent: 2
+  - uid: 1165
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-9.5
+      parent: 2
+  - uid: 1174
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-10.5
+      parent: 2
+  - uid: 1175
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-10.5
+      parent: 2
+  - uid: 1178
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-12.5
+      parent: 2
+  - uid: 1179
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-11.5
+      parent: 2
+  - uid: 1182
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,-13.5
+      parent: 2
+  - uid: 1249
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-11.5
+      parent: 2
+  - uid: 1251
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-11.5
+      parent: 2
+  - uid: 1253
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-10.5
+      parent: 2
+  - uid: 1301
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-15.5
+      parent: 2
+  - uid: 1305
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-16.5
+      parent: 2
+  - uid: 1423
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-15.5
+      parent: 2
+  - uid: 1425
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-12.5
+      parent: 2
+  - uid: 1426
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-15.5
+      parent: 2
+  - uid: 1429
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-16.5
+      parent: 2
+  - uid: 1430
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-15.5
+      parent: 2
+  - uid: 1627
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-15.5
+      parent: 2
+  - uid: 1632
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-14.5
+      parent: 2
+  - uid: 1633
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-14.5
+      parent: 2
+  - uid: 1634
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-16.5
+      parent: 2
+  - uid: 1635
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-10.5
+      parent: 2
+  - uid: 1636
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-13.5
+      parent: 2
+  - uid: 1637
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,-14.5
+      parent: 2
+  - uid: 1648
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-12.5
+      parent: 2
+  - uid: 1654
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-8.5
+      parent: 2
+  - uid: 1760
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-13.5
+      parent: 2
+- proto: Stairs
+  entities:
+  - uid: 1208
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 2
+  - uid: 1209
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 2
+  - uid: 1210
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 2
+  - uid: 1211
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 2
+  - uid: 1212
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 2
+  - uid: 1213
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 2
+  - uid: 1214
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-8.5
+      parent: 2
+  - uid: 1215
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-7.5
+      parent: 2
+  - uid: 1216
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-6.5
+      parent: 2
+  - uid: 1217
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-5.5
+      parent: 2
+  - uid: 1218
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-4.5
+      parent: 2
+  - uid: 1219
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-4.5
+      parent: 2
+  - uid: 1220
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-5.5
+      parent: 2
+  - uid: 1221
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-5.5
+      parent: 2
+  - uid: 1222
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-6.5
+      parent: 2
+  - uid: 1223
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-6.5
+      parent: 2
+  - uid: 1224
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-9.5
+      parent: 2
+  - uid: 1225
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-8.5
+      parent: 2
+  - uid: 1226
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-7.5
+      parent: 2
+  - uid: 1227
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-6.5
+      parent: 2
+  - uid: 1228
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-5.5
+      parent: 2
+  - uid: 1229
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-7.5
+      parent: 2
+  - uid: 1230
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-7.5
+      parent: 2
+  - uid: 1231
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-8.5
+      parent: 2
+  - uid: 1232
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-8.5
+      parent: 2
+  - uid: 1233
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-9.5
+      parent: 2
+- proto: StairStage
+  entities:
+  - uid: 1234
+    components:
+    - type: Transform
+      pos: -7.5,-3.5
+      parent: 2
+  - uid: 1235
+    components:
+    - type: Transform
+      pos: 8.5,-3.5
+      parent: 2
+- proto: StoolBar
+  entities:
+  - uid: 699
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-8.5
+      parent: 2
+  - uid: 1743
+    components:
+    - type: Transform
+      pos: -6.5,-7.5
+      parent: 2
+  - uid: 1746
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-7.5
+      parent: 2
+  - uid: 1748
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-9.5
+      parent: 2
+  - uid: 1749
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 2
+  - uid: 1750
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-9.5
+      parent: 2
+  - uid: 1751
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 2
+  - uid: 1752
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-7.5
+      parent: 2
+  - uid: 1753
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-9.5
+      parent: 2
+- proto: SubstationBasic
+  entities:
+  - uid: 1243
+    components:
+    - type: Transform
+      pos: 5.5,-16.5
+      parent: 2
+- proto: SubstationWallBasic
+  entities:
+  - uid: 1244
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 2
+  - uid: 1245
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,4.5
+      parent: 2
+  - uid: 1246
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 2
+- proto: Table
+  entities:
+  - uid: 145
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,7.5
+      parent: 2
+  - uid: 146
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,8.5
+      parent: 2
+  - uid: 986
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,-16.5
+      parent: 2
+  - uid: 1149
+    components:
+    - type: Transform
+      pos: -10.5,4.5
+      parent: 2
+  - uid: 1150
+    components:
+    - type: Transform
+      pos: -11.5,4.5
+      parent: 2
+  - uid: 1158
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,-15.5
+      parent: 2
+  - uid: 1161
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,-16.5
+      parent: 2
+  - uid: 1650
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-16.5
+      parent: 2
+  - uid: 1757
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-10.5
+      parent: 2
+  - uid: 1758
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-16.5
+      parent: 2
+- proto: TableReinforced
+  entities:
+  - uid: 1254
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,5.5
+      parent: 2
+  - uid: 1255
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,5.5
+      parent: 2
+  - uid: 1256
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,4.5
+      parent: 2
+  - uid: 1257
+    components:
+    - type: Transform
+      pos: 8.5,6.5
+      parent: 2
+  - uid: 1258
+    components:
+    - type: Transform
+      pos: 9.5,6.5
+      parent: 2
+  - uid: 1259
+    components:
+    - type: Transform
+      pos: 9.5,7.5
+      parent: 2
+  - uid: 1260
+    components:
+    - type: Transform
+      pos: 8.5,7.5
+      parent: 2
+  - uid: 1261
+    components:
+    - type: Transform
+      pos: 8.5,8.5
+      parent: 2
+  - uid: 1262
+    components:
+    - type: Transform
+      pos: 9.5,8.5
+      parent: 2
+  - uid: 1744
+    components:
+    - type: Transform
+      pos: 11.5,7.5
+      parent: 2
+  - uid: 1747
+    components:
+    - type: Transform
+      pos: 11.5,6.5
+      parent: 2
+- proto: TableWoodReinforced
+  entities:
+  - uid: 1050
+    components:
+    - type: Transform
+      pos: -0.5,-7.5
+      parent: 2
+  - uid: 1267
+    components:
+    - type: Transform
+      pos: -0.5,-6.5
+      parent: 2
+  - uid: 1306
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 2
+  - uid: 1307
+    components:
+    - type: Transform
+      pos: 1.5,-8.5
+      parent: 2
+  - uid: 1308
+    components:
+    - type: Transform
+      pos: 1.5,-6.5
+      parent: 2
+  - uid: 1628
+    components:
+    - type: Transform
+      pos: 0.5,-8.5
+      parent: 2
+  - uid: 1630
+    components:
+    - type: Transform
+      pos: -0.5,-8.5
+      parent: 2
+  - uid: 1639
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 2
+  - uid: 1640
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 2
+- proto: Thruster
+  entities:
+  - uid: 1269
+    components:
+    - type: Transform
+      rot: -3.141592653589793 rad
+      pos: -9.5,-18.5
+      parent: 2
+  - uid: 1270
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 2
+  - uid: 1271
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 2
+  - uid: 1272
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,10.5
+      parent: 2
+  - uid: 1273
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,9.5
+      parent: 2
+  - uid: 1274
+    components:
+    - type: Transform
+      rot: -3.141592653589793 rad
+      pos: -8.5,-18.5
+      parent: 2
+  - uid: 1275
+    components:
+    - type: Transform
+      rot: -3.141592653589793 rad
+      pos: -7.5,-18.5
+      parent: 2
+  - uid: 1276
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-14.5
+      parent: 2
+  - uid: 1277
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-15.5
+      parent: 2
+  - uid: 1278
+    components:
+    - type: Transform
+      rot: -3.141592653589793 rad
+      pos: 9.5,-18.5
+      parent: 2
+  - uid: 1279
+    components:
+    - type: Transform
+      rot: -3.141592653589793 rad
+      pos: 10.5,-18.5
+      parent: 2
+  - uid: 1280
+    components:
+    - type: Transform
+      rot: -3.141592653589793 rad
+      pos: 8.5,-18.5
+      parent: 2
+  - uid: 1281
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 2
+  - uid: 1282
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-0.5
+      parent: 2
+  - uid: 1283
+    components:
+    - type: Transform
+      rot: -3.141592653589793 rad
+      pos: -4.5,3.5
+      parent: 2
+  - uid: 1284
+    components:
+    - type: Transform
+      rot: -10.995574287564276 rad
+      pos: -12.5,-15.5
+      parent: 2
+  - uid: 1285
+    components:
+    - type: Transform
+      rot: -10.995574287564276 rad
+      pos: -12.5,-14.5
+      parent: 2
+  - uid: 1286
+    components:
+    - type: Transform
+      rot: -4.71238898038469 rad
+      pos: -11.5,9.5
+      parent: 2
+  - uid: 1287
+    components:
+    - type: Transform
+      rot: -4.71238898038469 rad
+      pos: -11.5,10.5
+      parent: 2
+  - uid: 1288
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 2
+  - uid: 1289
+    components:
+    - type: Transform
+      rot: -3.141592653589793 rad
+      pos: 5.5,3.5
+      parent: 2
+  - uid: 1290
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 2
+  - uid: 1291
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-0.5
+      parent: 2
+  - uid: 1292
+    components:
+    - type: Transform
+      pos: 5.5,-1.5
+      parent: 2
+- proto: ToiletDirtyWater
+  entities:
+  - uid: 1293
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-4.5
+      parent: 2
+  - uid: 1294
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-4.5
+      parent: 2
+  - uid: 1295
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-3.5
+      parent: 2
+- proto: ToolboxElectricalFilled
+  entities:
+  - uid: 1296
+    components:
+    - type: Transform
+      pos: 8.328063,-10.726057
+      parent: 2
+- proto: ToolboxMechanicalFilled
+  entities:
+  - uid: 1297
+    components:
+    - type: Transform
+      pos: 8.311531,-10.517394
+      parent: 2
+- proto: TwoWayLever
+  entities:
+  - uid: 1298
+    components:
+    - type: Transform
+      pos: 0.5,-13.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        200:
+        - Left: Open
+        - Right: Open
+        - Middle: Close
+        201:
+        - Left: Open
+        - Right: Open
+        - Middle: Close
+        202:
+        - Left: Open
+        - Right: Open
+        - Middle: Close
+- proto: VendingMachineBooze
+  entities:
+  - uid: 1167
+    components:
+    - type: Transform
+      pos: -2.5,-10.5
+      parent: 2
+- proto: VendingMachineBountyVend
+  entities:
+  - uid: 1300
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 2
+- proto: VendingMachineClothing
+  entities:
+  - uid: 1302
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 2
+- proto: VendingMachineEngiDrobe
+  entities:
+  - uid: 1303
+    components:
+    - type: Transform
+      pos: 9.5,-9.5
+      parent: 2
+- proto: VendingMachineTankDispenserEVA
+  entities:
+  - uid: 1241
+    components:
+    - type: Transform
+      pos: -1.5,-12.5
+      parent: 2
+  - uid: 1299
+    components:
+    - type: Transform
+      pos: -8.5,0.5
+      parent: 2
+  - uid: 1310
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 2
+- proto: VendingMachineWinter
+  entities:
+  - uid: 1312
+    components:
+    - type: Transform
+      pos: -5.5,-3.5
+      parent: 2
+- proto: VendingMachineYouTool
+  entities:
+  - uid: 1313
+    components:
+    - type: Transform
+      pos: 7.5,-10.5
+      parent: 2
+- proto: WallPlastitaniumDiagonal
+  entities:
+  - uid: 659
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,10.5
+      parent: 2
+  - uid: 999
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,12.5
+      parent: 2
+  - uid: 1010
+    components:
+    - type: Transform
+      pos: -4.5,10.5
+      parent: 2
+  - uid: 1159
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,10.5
+      parent: 2
+  - uid: 1189
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,14.5
+      parent: 2
+  - uid: 1192
+    components:
+    - type: Transform
+      pos: 4.5,14.5
+      parent: 2
+  - uid: 1564
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -12.5,-6.5
+      parent: 2
+  - uid: 1565
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,12.5
+      parent: 2
+  - uid: 1566
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 2
+  - uid: 1567
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,3.5
+      parent: 2
+  - uid: 1568
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-2.5
+      parent: 2
+  - uid: 1569
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-2.5
+      parent: 2
+  - uid: 1570
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-4.5
+      parent: 2
+  - uid: 1571
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,6.5
+      parent: 2
+  - uid: 1572
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 2
+  - uid: 1573
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-4.5
+      parent: 2
+  - uid: 1574
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-17.5
+      parent: 2
+  - uid: 1575
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,12.5
+      parent: 2
+  - uid: 1576
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-4.5
+      parent: 2
+  - uid: 1577
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-18.5
+      parent: 2
+  - uid: 1579
+    components:
+    - type: Transform
+      pos: 4.5,-3.5
+      parent: 2
+  - uid: 1580
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-3.5
+      parent: 2
+  - uid: 1581
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,4.5
+      parent: 2
+  - uid: 1582
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,10.5
+      parent: 2
+  - uid: 1583
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,8.5
+      parent: 2
+  - uid: 1584
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,8.5
+      parent: 2
+  - uid: 1586
+    components:
+    - type: Transform
+      pos: -11.5,12.5
+      parent: 2
+  - uid: 1587
+    components:
+    - type: Transform
+      pos: -6.5,14.5
+      parent: 2
+  - uid: 1588
+    components:
+    - type: Transform
+      pos: -13.5,4.5
+      parent: 2
+  - uid: 1590
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -13.5,-3.5
+      parent: 2
+  - uid: 1591
+    components:
+    - type: Transform
+      pos: -11.5,-11.5
+      parent: 2
+  - uid: 1592
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,4.5
+      parent: 2
+  - uid: 1593
+    components:
+    - type: Transform
+      pos: -8.5,13.5
+      parent: 2
+  - uid: 1594
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-9.5
+      parent: 2
+  - uid: 1595
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -12.5,-16.5
+      parent: 2
+  - uid: 1596
+    components:
+    - type: Transform
+      pos: -12.5,-13.5
+      parent: 2
+  - uid: 1597
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-18.5
+      parent: 2
+  - uid: 1598
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-18.5
+      parent: 2
+  - uid: 1599
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,4.5
+      parent: 2
+  - uid: 1600
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,8.5
+      parent: 2
+  - uid: 1601
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,12.5
+      parent: 2
+  - uid: 1602
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,12.5
+      parent: 2
+  - uid: 1603
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-8.5
+      parent: 2
+  - uid: 1604
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-9.5
+      parent: 2
+  - uid: 1605
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-18.5
+      parent: 2
+  - uid: 1606
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-17.5
+      parent: 2
+  - uid: 1608
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-13.5
+      parent: 2
+  - uid: 1609
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-11.5
+      parent: 2
+  - uid: 1610
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-16.5
+      parent: 2
+  - uid: 1611
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-9.5
+      parent: 2
+  - uid: 1613
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-3.5
+      parent: 2
+  - uid: 1614
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-6.5
+      parent: 2
+  - uid: 1615
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,14.5
+      parent: 2
+  - uid: 1616
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,13.5
+      parent: 2
+  - uid: 1617
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-4.5
+      parent: 2
+  - uid: 1618
+    components:
+    - type: Transform
+      pos: 7.5,-8.5
+      parent: 2
+  - uid: 1619
+    components:
+    - type: Transform
+      pos: 4.5,-9.5
+      parent: 2
+  - uid: 1620
+    components:
+    - type: Transform
+      pos: -12.5,8.5
+      parent: 2
+  - uid: 1621
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,8.5
+      parent: 2
+  - uid: 1622
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,1.5
+      parent: 2
+  - uid: 1623
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-0.5
+      parent: 2
+  - uid: 1624
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,1.5
+      parent: 2
+  - uid: 1625
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 2
+  - uid: 1662
+    components:
+    - type: Transform
+      pos: 2.5,13.5
+      parent: 2
+  - uid: 1665
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,13.5
+      parent: 2
+- proto: WallPlastitaniumShuttle
+  entities:
+  - uid: 65
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,14.5
+      parent: 2
+  - uid: 108
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,14.5
+      parent: 2
+  - uid: 125
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,13.5
+      parent: 2
+  - uid: 127
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,13.5
+      parent: 2
+  - uid: 130
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,13.5
+      parent: 2
+  - uid: 989
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,13.5
+      parent: 2
+  - uid: 1074
+    components:
+    - type: Transform
+      pos: -3.5,10.5
+      parent: 2
+  - uid: 1100
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,12.5
+      parent: 2
+  - uid: 1183
+    components:
+    - type: Transform
+      pos: -3.5,12.5
+      parent: 2
+  - uid: 1186
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,12.5
+      parent: 2
+  - uid: 1250
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,12.5
+      parent: 2
+  - uid: 1314
+    components:
+    - type: Transform
+      pos: -9.5,-5.5
+      parent: 2
+  - uid: 1315
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-0.5
+      parent: 2
+  - uid: 1316
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,2.5
+      parent: 2
+  - uid: 1317
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,1.5
+      parent: 2
+  - uid: 1318
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-1.5
+      parent: 2
+  - uid: 1319
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-2.5
+      parent: 2
+  - uid: 1320
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-2.5
+      parent: 2
+  - uid: 1321
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-3.5
+      parent: 2
+  - uid: 1322
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,3.5
+      parent: 2
+  - uid: 1323
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-2.5
+      parent: 2
+  - uid: 1324
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-1.5
+      parent: 2
+  - uid: 1325
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-0.5
+      parent: 2
+  - uid: 1326
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 2
+  - uid: 1327
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,3.5
+      parent: 2
+  - uid: 1328
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,5.5
+      parent: 2
+  - uid: 1329
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,1.5
+      parent: 2
+  - uid: 1330
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,4.5
+      parent: 2
+  - uid: 1331
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,2.5
+      parent: 2
+  - uid: 1332
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 2
+  - uid: 1333
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-2.5
+      parent: 2
+  - uid: 1334
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-3.5
+      parent: 2
+  - uid: 1335
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,5.5
+      parent: 2
+  - uid: 1336
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,4.5
+      parent: 2
+  - uid: 1337
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-4.5
+      parent: 2
+  - uid: 1338
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-2.5
+      parent: 2
+  - uid: 1339
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-3.5
+      parent: 2
+  - uid: 1340
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-17.5
+      parent: 2
+  - uid: 1341
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-3.5
+      parent: 2
+  - uid: 1342
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-11.5
+      parent: 2
+  - uid: 1343
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-1.5
+      parent: 2
+  - uid: 1344
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-1.5
+      parent: 2
+  - uid: 1345
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-4.5
+      parent: 2
+  - uid: 1346
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-0.5
+      parent: 2
+  - uid: 1347
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,1.5
+      parent: 2
+  - uid: 1348
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-0.5
+      parent: 2
+  - uid: 1349
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,1.5
+      parent: 2
+  - uid: 1350
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,2.5
+      parent: 2
+  - uid: 1351
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,5.5
+      parent: 2
+  - uid: 1352
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,4.5
+      parent: 2
+  - uid: 1353
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,5.5
+      parent: 2
+  - uid: 1354
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,3.5
+      parent: 2
+  - uid: 1355
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,6.5
+      parent: 2
+  - uid: 1356
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,7.5
+      parent: 2
+  - uid: 1357
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,8.5
+      parent: 2
+  - uid: 1358
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,9.5
+      parent: 2
+  - uid: 1359
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,9.5
+      parent: 2
+  - uid: 1361
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,14.5
+      parent: 2
+  - uid: 1362
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,13.5
+      parent: 2
+  - uid: 1363
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,10.5
+      parent: 2
+  - uid: 1364
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,12.5
+      parent: 2
+  - uid: 1365
+    components:
+    - type: Transform
+      pos: -10.5,11.5
+      parent: 2
+  - uid: 1366
+    components:
+    - type: Transform
+      pos: -9.5,11.5
+      parent: 2
+  - uid: 1367
+    components:
+    - type: Transform
+      pos: -10.5,12.5
+      parent: 2
+  - uid: 1368
+    components:
+    - type: Transform
+      pos: -9.5,12.5
+      parent: 2
+  - uid: 1369
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,14.5
+      parent: 2
+  - uid: 1370
+    components:
+    - type: Transform
+      pos: -11.5,8.5
+      parent: 2
+  - uid: 1371
+    components:
+    - type: Transform
+      pos: -12.5,6.5
+      parent: 2
+  - uid: 1372
+    components:
+    - type: Transform
+      pos: -12.5,7.5
+      parent: 2
+  - uid: 1373
+    components:
+    - type: Transform
+      pos: -12.5,5.5
+      parent: 2
+  - uid: 1374
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,3.5
+      parent: 2
+  - uid: 1375
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,3.5
+      parent: 2
+  - uid: 1376
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,3.5
+      parent: 2
+  - uid: 1377
+    components:
+    - type: Transform
+      pos: -12.5,-1.5
+      parent: 2
+  - uid: 1378
+    components:
+    - type: Transform
+      pos: -11.5,-5.5
+      parent: 2
+  - uid: 1379
+    components:
+    - type: Transform
+      pos: -8.5,-2.5
+      parent: 2
+  - uid: 1380
+    components:
+    - type: Transform
+      pos: -9.5,-2.5
+      parent: 2
+  - uid: 1381
+    components:
+    - type: Transform
+      pos: -10.5,-2.5
+      parent: 2
+  - uid: 1382
+    components:
+    - type: Transform
+      pos: -11.5,-2.5
+      parent: 2
+  - uid: 1383
+    components:
+    - type: Transform
+      pos: -13.5,-2.5
+      parent: 2
+  - uid: 1384
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-8.5
+      parent: 2
+  - uid: 1385
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-8.5
+      parent: 2
+  - uid: 1386
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-9.5
+      parent: 2
+  - uid: 1387
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-9.5
+      parent: 2
+  - uid: 1388
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,6.5
+      parent: 2
+  - uid: 1389
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,2.5
+      parent: 2
+  - uid: 1390
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,7.5
+      parent: 2
+  - uid: 1391
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,9.5
+      parent: 2
+  - uid: 1392
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,3.5
+      parent: 2
+  - uid: 1393
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,4.5
+      parent: 2
+  - uid: 1394
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,5.5
+      parent: 2
+  - uid: 1395
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-15.5
+      parent: 2
+  - uid: 1396
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-16.5
+      parent: 2
+  - uid: 1397
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-17.5
+      parent: 2
+  - uid: 1398
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-14.5
+      parent: 2
+  - uid: 1399
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-13.5
+      parent: 2
+  - uid: 1400
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-12.5
+      parent: 2
+  - uid: 1401
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,8.5
+      parent: 2
+  - uid: 1402
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 2
+  - uid: 1403
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-14.5
+      parent: 2
+  - uid: 1404
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,13.5
+      parent: 2
+  - uid: 1405
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,13.5
+      parent: 2
+  - uid: 1406
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,11.5
+      parent: 2
+  - uid: 1407
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,11.5
+      parent: 2
+  - uid: 1408
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-9.5
+      parent: 2
+  - uid: 1409
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-10.5
+      parent: 2
+  - uid: 1410
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-11.5
+      parent: 2
+  - uid: 1411
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-12.5
+      parent: 2
+  - uid: 1412
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-11.5
+      parent: 2
+  - uid: 1413
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-15.5
+      parent: 2
+  - uid: 1414
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-15.5
+      parent: 2
+  - uid: 1415
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-18.5
+      parent: 2
+  - uid: 1416
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-17.5
+      parent: 2
+  - uid: 1417
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-17.5
+      parent: 2
+  - uid: 1418
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-17.5
+      parent: 2
+  - uid: 1419
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-17.5
+      parent: 2
+  - uid: 1420
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-17.5
+      parent: 2
+  - uid: 1421
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,9.5
+      parent: 2
+  - uid: 1422
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,12.5
+      parent: 2
+  - uid: 1424
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,13.5
+      parent: 2
+  - uid: 1427
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,13.5
+      parent: 2
+  - uid: 1428
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,13.5
+      parent: 2
+  - uid: 1431
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-9.5
+      parent: 2
+  - uid: 1432
+    components:
+    - type: Transform
+      pos: -12.5,-2.5
+      parent: 2
+  - uid: 1433
+    components:
+    - type: Transform
+      pos: -8.5,-5.5
+      parent: 2
+  - uid: 1434
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,3.5
+      parent: 2
+  - uid: 1435
+    components:
+    - type: Transform
+      pos: -11.5,6.5
+      parent: 2
+  - uid: 1436
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-10.5
+      parent: 2
+  - uid: 1437
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-11.5
+      parent: 2
+  - uid: 1438
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-13.5
+      parent: 2
+  - uid: 1439
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-14.5
+      parent: 2
+  - uid: 1440
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-16.5
+      parent: 2
+  - uid: 1441
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-17.5
+      parent: 2
+  - uid: 1442
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-16.5
+      parent: 2
+  - uid: 1443
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-17.5
+      parent: 2
+  - uid: 1444
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-11.5
+      parent: 2
+  - uid: 1445
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-7.5
+      parent: 2
+  - uid: 1446
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-8.5
+      parent: 2
+  - uid: 1447
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-8.5
+      parent: 2
+  - uid: 1448
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-10.5
+      parent: 2
+  - uid: 1449
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-11.5
+      parent: 2
+  - uid: 1450
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-12.5
+      parent: 2
+  - uid: 1451
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-11.5
+      parent: 2
+  - uid: 1452
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-9.5
+      parent: 2
+  - uid: 1453
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-12.5
+      parent: 2
+  - uid: 1454
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-17.5
+      parent: 2
+  - uid: 1455
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-15.5
+      parent: 2
+  - uid: 1456
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-18.5
+      parent: 2
+  - uid: 1457
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-17.5
+      parent: 2
+  - uid: 1458
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,-17.5
+      parent: 2
+  - uid: 1459
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-16.5
+      parent: 2
+  - uid: 1460
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-17.5
+      parent: 2
+  - uid: 1461
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-17.5
+      parent: 2
+  - uid: 1462
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-17.5
+      parent: 2
+  - uid: 1463
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-17.5
+      parent: 2
+  - uid: 1464
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,-18.5
+      parent: 2
+  - uid: 1465
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,-17.5
+      parent: 2
+  - uid: 1466
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-17.5
+      parent: 2
+  - uid: 1467
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-16.5
+      parent: 2
+  - uid: 1468
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-14.5
+      parent: 2
+  - uid: 1469
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-15.5
+      parent: 2
+  - uid: 1470
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-13.5
+      parent: 2
+  - uid: 1471
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-12.5
+      parent: 2
+  - uid: 1472
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,-11.5
+      parent: 2
+  - uid: 1473
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,-12.5
+      parent: 2
+  - uid: 1474
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-13.5
+      parent: 2
+  - uid: 1475
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-10.5
+      parent: 2
+  - uid: 1476
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-10.5
+      parent: 2
+  - uid: 1477
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-9.5
+      parent: 2
+  - uid: 1478
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-9.5
+      parent: 2
+  - uid: 1479
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-9.5
+      parent: 2
+  - uid: 1480
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-8.5
+      parent: 2
+  - uid: 1481
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-8.5
+      parent: 2
+  - uid: 1482
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,-8.5
+      parent: 2
+  - uid: 1483
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,-9.5
+      parent: 2
+  - uid: 1484
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,-10.5
+      parent: 2
+  - uid: 1485
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-8.5
+      parent: 2
+  - uid: 1486
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-9.5
+      parent: 2
+  - uid: 1487
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-16.5
+      parent: 2
+  - uid: 1488
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-7.5
+      parent: 2
+  - uid: 1489
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-6.5
+      parent: 2
+  - uid: 1490
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-5.5
+      parent: 2
+  - uid: 1491
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,-4.5
+      parent: 2
+  - uid: 1492
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,-3.5
+      parent: 2
+  - uid: 1493
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,-2.5
+      parent: 2
+  - uid: 1494
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,-1.5
+      parent: 2
+  - uid: 1495
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,2.5
+      parent: 2
+  - uid: 1496
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,0.5
+      parent: 2
+  - uid: 1497
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,2.5
+      parent: 2
+  - uid: 1498
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,0.5
+      parent: 2
+  - uid: 1499
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,3.5
+      parent: 2
+  - uid: 1500
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,4.5
+      parent: 2
+  - uid: 1501
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,5.5
+      parent: 2
+  - uid: 1502
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,7.5
+      parent: 2
+  - uid: 1503
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,8.5
+      parent: 2
+  - uid: 1504
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,3.5
+      parent: 2
+  - uid: 1505
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,-5.5
+      parent: 2
+  - uid: 1506
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,-2.5
+      parent: 2
+  - uid: 1507
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,3.5
+      parent: 2
+  - uid: 1508
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,6.5
+      parent: 2
+  - uid: 1509
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,7.5
+      parent: 2
+  - uid: 1510
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,11.5
+      parent: 2
+  - uid: 1511
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,11.5
+      parent: 2
+  - uid: 1512
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,12.5
+      parent: 2
+  - uid: 1513
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,12.5
+      parent: 2
+  - uid: 1514
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,12.5
+      parent: 2
+  - uid: 1515
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,2.5
+      parent: 2
+  - uid: 1516
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,2.5
+      parent: 2
+  - uid: 1517
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-2.5
+      parent: 2
+  - uid: 1518
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,3.5
+      parent: 2
+  - uid: 1519
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,-1.5
+      parent: 2
+  - uid: 1520
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-4.5
+      parent: 2
+  - uid: 1521
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,0.5
+      parent: 2
+  - uid: 1522
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,3.5
+      parent: 2
+  - uid: 1523
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,3.5
+      parent: 2
+  - uid: 1524
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,3.5
+      parent: 2
+  - uid: 1525
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-2.5
+      parent: 2
+  - uid: 1526
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,-2.5
+      parent: 2
+  - uid: 1527
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,3.5
+      parent: 2
+  - uid: 1528
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-4.5
+      parent: 2
+  - uid: 1529
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,-2.5
+      parent: 2
+  - uid: 1530
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-2.5
+      parent: 2
+  - uid: 1531
+    components:
+    - type: Transform
+      pos: -12.5,-3.5
+      parent: 2
+  - uid: 1532
+    components:
+    - type: Transform
+      pos: -13.5,0.5
+      parent: 2
+  - uid: 1533
+    components:
+    - type: Transform
+      pos: -12.5,0.5
+      parent: 2
+  - uid: 1534
+    components:
+    - type: Transform
+      pos: -11.5,0.5
+      parent: 2
+  - uid: 1535
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-2.5
+      parent: 2
+  - uid: 1536
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,4.5
+      parent: 2
+  - uid: 1537
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,2.5
+      parent: 2
+  - uid: 1538
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-1.5
+      parent: 2
+  - uid: 1539
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-15.5
+      parent: 2
+  - uid: 1540
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,2.5
+      parent: 2
+  - uid: 1541
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-5.5
+      parent: 2
+  - uid: 1542
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,-5.5
+      parent: 2
+  - uid: 1543
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,3.5
+      parent: 2
+  - uid: 1544
+    components:
+    - type: Transform
+      pos: -12.5,-5.5
+      parent: 2
+  - uid: 1545
+    components:
+    - type: Transform
+      pos: -11.5,-6.5
+      parent: 2
+  - uid: 1546
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,3.5
+      parent: 2
+  - uid: 1547
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-18.5
+      parent: 2
+  - uid: 1548
+    components:
+    - type: Transform
+      pos: -12.5,-4.5
+      parent: 2
+  - uid: 1549
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-2.5
+      parent: 2
+  - uid: 1550
+    components:
+    - type: Transform
+      pos: -11.5,-1.5
+      parent: 2
+  - uid: 1551
+    components:
+    - type: Transform
+      pos: -13.5,-1.5
+      parent: 2
+  - uid: 1552
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-1.5
+      parent: 2
+  - uid: 1553
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-1.5
+      parent: 2
+  - uid: 1554
+    components:
+    - type: Transform
+      pos: -10.5,9.5
+      parent: 2
+  - uid: 1555
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,10.5
+      parent: 2
+  - uid: 1556
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,12.5
+      parent: 2
+  - uid: 1557
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,11.5
+      parent: 2
+  - uid: 1558
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,9.5
+      parent: 2
+  - uid: 1559
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,6.5
+      parent: 2
+  - uid: 1560
+    components:
+    - type: Transform
+      pos: -10.5,10.5
+      parent: 2
+  - uid: 1561
+    components:
+    - type: Transform
+      pos: -11.5,11.5
+      parent: 2
+  - uid: 1562
+    components:
+    - type: Transform
+      pos: -11.5,7.5
+      parent: 2
+  - uid: 1651
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,8.5
+      parent: 2
+- proto: WallWeaponCapacitorRecharger
+  entities:
+  - uid: 1268
+    components:
+    - type: Transform
+      pos: 12.5,7.5
+      parent: 2
+  - uid: 1713
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 2
+- proto: WarpPointShip
+  entities:
+  - uid: 1152
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 2
+- proto: WeaponCapacitorRecharger
+  entities:
+  - uid: 1248
+    components:
+    - type: Transform
+      pos: 8.5,7.5
+      parent: 2
+- proto: WeaponCrusher
+  entities:
+  - uid: 1643
+    components:
+    - type: Transform
+      pos: 2.448414,-13.40642
+      parent: 2
+- proto: WeaponCrusherGlaive
+  entities:
+  - uid: 1642
+    components:
+    - type: Transform
+      pos: 2.6220253,-13.580031
+      parent: 2
+- proto: WeaponDisabler
+  entities:
+  - uid: 697
+    components:
+    - type: Transform
+      pos: 11.518778,7.158044
+      parent: 2
+  - uid: 1732
+    components:
+    - type: Transform
+      pos: 11.518778,6.673669
+      parent: 2
+- proto: WeaponRifleNovaliteC1
+  entities:
+  - uid: 653
+    components:
+    - type: Transform
+      pos: -9.536149,8.404913
+      parent: 2
+- proto: WeaponSVT
+  entities:
+  - uid: 1667
+    components:
+    - type: Transform
+      parent: 987
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: WindoorSecure
+  entities:
+  - uid: 126
+    components:
+    - type: Transform
+      pos: -10.5,7.5
+      parent: 2
+  - uid: 755
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,9.5
+      parent: 2
+  - uid: 976
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,10.5
+      parent: 2
+- proto: WindowReinforcedDirectional
+  entities:
+  - uid: 128
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,7.5
+      parent: 2
+  - uid: 131
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,10.5
+      parent: 2
+  - uid: 134
+    components:
+    - type: Transform
+      pos: -8.5,10.5
+      parent: 2
+  - uid: 135
+    components:
+    - type: Transform
+      pos: -7.5,10.5
+      parent: 2
+  - uid: 136
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,10.5
+      parent: 2
+  - uid: 346
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,8.5
+      parent: 2
+  - uid: 683
+    components:
+    - type: Transform
+      pos: -9.5,7.5
+      parent: 2
+  - uid: 994
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-10.5
+      parent: 2
+  - uid: 1003
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-16.5
+      parent: 2
+  - uid: 1163
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-16.5
+      parent: 2
+  - uid: 1649
+    components:
+    - type: Transform
+      pos: -7.5,-12.5
+      parent: 2
+  - uid: 1655
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-13.5
+      parent: 2
+  - uid: 1721
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-10.5
+      parent: 2
+  - uid: 1735
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,4.5
+      parent: 2
+  - uid: 1739
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,11.5
+      parent: 2
+...

--- a/Resources/Maps/Corvax/Shuttles/Expedition/ZaryaResearch.yml
+++ b/Resources/Maps/Corvax/Shuttles/Expedition/ZaryaResearch.yml
@@ -1,0 +1,12529 @@
+meta:
+  format: 6
+  postmapinit: false
+tilemap:
+  0: Space
+  7: FloorAsteroidSandRed
+  3: FloorDark
+  6: FloorDarkPlastic
+  4: FloorElevatorShaft
+  69: FloorMetalDiamond
+  83: FloorReinforced
+  97: FloorSteel
+  104: FloorSteelDirty
+  5: FloorTechMaint
+  129: Lattice
+  130: Plating
+  1: PlatingBurnt
+  2: PlatingDamaged
+entities:
+- proto: ""
+  entities:
+  - uid: 2
+    components:
+    - type: MetaData
+      name: Заря
+    - type: Transform
+      pos: -0.53125,-0.5
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: AwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAgQAAAAAAgQAAAAAABAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAAAAAAAAAgQAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAAAAAAAAAAAwAAAAAAAwAAAAAAggAAAAAAggAAAAAAAAAAAAAAgQAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAwAAAAAAAwAAAAAAggAAAAAAgQAAAAAAAAAAAAAAgQAAAAAAggAAAAAAggAAAAAAAwAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAwAAAAAAAwAAAAAAggAAAAAAgQAAAAAAAAAAAAAAgQAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAwAAAAAAAwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAAAAAAAAAAAAAAAAABAAAAAAABAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAgQAAAAAAAAAAAAAAggAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAggAAAAAAgQAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAABAgAAAAAAgQAAAAAAgQAAAAAABAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAABAgAAAAAAggAAAAAAgQAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAgQAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAAggAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAABwAAAAAABwAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        0,-1:
+          ind: 0,-1
+          tiles: BAAAAAAABAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAABQAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAggAAAAAAggAAAAAABQAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAggAAAAAAggAAAAAABQAAAAAAggAAAAAAggAAAAAAggAAAAAABQAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAABAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAABQAAAAAAggAAAAAAggAAAAAAggAAAAAABQAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAggAAAAAABQAAAAAAggAAAAAAggAAAAAAggAAAAAABQAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAABQAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAggAAAAAABAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAggAAAAAARQAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAARQAAAAAARQAAAAAARQAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAwAAAAAAggAAAAAAgQAAAAAAgQAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAARQAAAAAARQAAAAAARQAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAwAAAAAAAwAAAAAAggAAAAAAgQAAAAAAgQAAAAAAggAAAAAAggAAAAAAggAAAAAAAwAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAwAAAAAAAwAAAAAAggAAAAAAggAAAAAAgQAAAAAAgQAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAgQAAAAAAgQAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAAAAAAAAAA
+          version: 6
+        -1,0:
+          ind: -1,0
+          tiles: AAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAgQAAAAAAgQAAAAAABAAAAAAAAwAAAAAAAwAAAAAAAAAAAAAAAAAAAAAABAAAAAAABAAAAAAABAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAgQAAAAAAAAAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAgQAAAAAAAAAAAAAAggAAAAAAggAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAABAAAAAAABAAAAAAAggAAAAAAgQAAAAAAAAAAAAAAgQAAAAAAggAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAgQAAAAAAAAAAAAAAgQAAAAAAggAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAggAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAAgAAAAABAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAgQAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAggAAAAAAAAAAAAAAgQAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAgQAAAAAAggAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAgQAAAAAAgQAAAAAAAgAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAgQAAAAAAggAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAgQAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        -1,-1:
+          ind: -1,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAggAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAggAAAAAAggAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAAwAAAAAAAwAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAABAAAAAAAggAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAARQAAAAAAggAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAARQAAAAAARQAAAAAARQAAAAAABAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAARQAAAAAARQAAAAAARQAAAAAABAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAgQAAAAAAgQAAAAAAggAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAwAAAAAAggAAAAAAggAAAAAAggAAAAAAgQAAAAAAgQAAAAAAggAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAgQAAAAAAgQAAAAAAggAAAAAAggAAAAAAAwAAAAAAAAAAAAAAAAAAAAAABAAAAAAABAAAAAAABAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAgQAAAAAAgQAAAAAAggAAAAAAAwAAAAAAAwAAAAAA
+          version: 6
+        -1,-2:
+          ind: -1,-2
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAggAAAAAAggAAAAAAgQAAAAAAgQAAAAAA
+          version: 6
+        0,-2:
+          ind: 0,-2
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAggAAAAAAggAAAAAAggAAAAAABQAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        0,1:
+          ind: 0,1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            angle: -1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: BoxGreyscale
+          decals:
+            198: -1,-15
+            199: -1,-13
+            200: 1,-13
+            201: 1,-15
+            202: -9,2
+            203: 9,-2
+            204: 9,2
+            205: -9,-2
+        - node:
+            color: '#8CB7E8FF'
+            id: BrickCornerOverlayNW
+          decals:
+            225: -11,-14
+        - node:
+            color: '#8CB7E8FF'
+            id: BrickCornerOverlaySW
+          decals:
+            251: -11,-17
+        - node:
+            color: '#8CB7E8FF'
+            id: BrickLineOverlayE
+          decals:
+            230: -8,-14
+            231: -8,-17
+            232: -5,-17
+            233: -4,-16
+            234: -4,-15
+            235: -4,-14
+            236: -4,-13
+            237: -5,-12
+            238: -6,-11
+            239: -9,-10
+        - node:
+            color: '#8CB7E8FF'
+            id: BrickLineOverlayN
+          decals:
+            228: -9,-14
+            229: -8,-14
+            240: -8,-11
+            241: -6,-11
+            242: -7,-11
+            243: -5,-12
+            244: -4,-13
+            245: -9,-10
+        - node:
+            color: '#8CB7E8FF'
+            id: BrickLineOverlayS
+          decals:
+            252: -10,-17
+            253: -9,-17
+            254: -8,-17
+            255: -7,-17
+            256: -6,-17
+            257: -5,-17
+            258: -4,-16
+        - node:
+            color: '#8CB7E8FF'
+            id: BrickLineOverlayW
+          decals:
+            226: -11,-15
+            227: -11,-16
+            246: -10,-10
+            247: -10,-11
+            248: -10,-12
+            249: -10,-13
+            250: -11,-16
+        - node:
+            color: '#459909FF'
+            id: BrickTileWhiteCornerNe
+          decals:
+            29: 9,11
+            30: 10,10
+            31: 12,5
+        - node:
+            color: '#4979AFFF'
+            id: BrickTileWhiteCornerNe
+          decals:
+            101: 1,5
+        - node:
+            color: '#EDB142FF'
+            id: BrickTileWhiteCornerNe
+          decals:
+            126: 11,-14
+        - node:
+            color: '#4979AFFF'
+            id: BrickTileWhiteCornerNw
+          decals:
+            102: -1,5
+        - node:
+            color: '#D181C7FF'
+            id: BrickTileWhiteCornerNw
+          decals:
+            59: -12,5
+            60: -10,10
+            61: -9,11
+        - node:
+            color: '#EDB142FF'
+            id: BrickTileWhiteCornerNw
+          decals:
+            119: 9,-10
+            120: 6,-11
+            121: 5,-12
+            122: 4,-13
+        - node:
+            color: '#459909FF'
+            id: BrickTileWhiteCornerSe
+          decals:
+            32: 12,4
+        - node:
+            color: '#D181C7FF'
+            id: BrickTileWhiteCornerSe
+          decals:
+            57: -7,4
+            58: -6,6
+        - node:
+            color: '#EDB142FF'
+            id: BrickTileWhiteCornerSe
+          decals:
+            125: 11,-17
+        - node:
+            color: '#459909FF'
+            id: BrickTileWhiteCornerSw
+          decals:
+            33: 6,6
+            34: 7,4
+        - node:
+            color: '#D181C7FF'
+            id: BrickTileWhiteCornerSw
+          decals:
+            56: -12,4
+        - node:
+            color: '#EDB142FF'
+            id: BrickTileWhiteCornerSw
+          decals:
+            123: 4,-16
+            124: 5,-17
+        - node:
+            color: '#459909FF'
+            id: BrickTileWhiteInnerNe
+          decals:
+            40: 11,5
+            43: 9,10
+        - node:
+            color: '#4979AFFF'
+            id: BrickTileWhiteInnerNe
+          decals:
+            100: 1,1
+            104: 2,0
+        - node:
+            color: '#D181C7FF'
+            id: BrickTileWhiteInnerNe
+          decals:
+            82: -5,11
+        - node:
+            color: '#EDB142FF'
+            id: BrickTileWhiteInnerNe
+          decals:
+            132: 10,-14
+        - node:
+            color: '#459909FF'
+            id: BrickTileWhiteInnerNw
+          decals:
+            45: 5,11
+        - node:
+            color: '#4979AFFF'
+            id: BrickTileWhiteInnerNw
+          decals:
+            99: -1,1
+            103: -2,0
+        - node:
+            color: '#D181C7FF'
+            id: BrickTileWhiteInnerNw
+          decals:
+            74: -9,10
+            75: -10,8
+            76: -11,5
+            87: -7,11
+        - node:
+            color: '#EDB142FF'
+            id: BrickTileWhiteInnerNw
+          decals:
+            127: 10,-10
+            144: 5,-13
+            145: 6,-12
+            146: 9,-11
+        - node:
+            color: '#459909FF'
+            id: BrickTileWhiteInnerSe
+          decals:
+            35: 8,4
+        - node:
+            color: '#4979AFFF'
+            id: BrickTileWhiteInnerSe
+          decals:
+            97: 1,-1
+            105: 2,0
+        - node:
+            color: '#D181C7FF'
+            id: BrickTileWhiteInnerSe
+          decals:
+            77: -8,4
+            79: -7,6
+            80: -6,10
+            81: -5,11
+        - node:
+            color: '#459909FF'
+            id: BrickTileWhiteInnerSw
+          decals:
+            36: 8,4
+            46: 5,11
+            47: 7,6
+        - node:
+            color: '#4979AFFF'
+            id: BrickTileWhiteInnerSw
+          decals:
+            98: -1,-1
+            106: -2,0
+        - node:
+            color: '#D181C7FF'
+            id: BrickTileWhiteInnerSw
+          decals:
+            78: -8,4
+        - node:
+            color: '#459909FF'
+            id: BrickTileWhiteLineE
+          decals:
+            41: 11,6
+            42: 11,7
+            48: 10,9
+        - node:
+            color: '#4979AFFF'
+            id: BrickTileWhiteLineE
+          decals:
+            92: 1,4
+            93: 1,3
+            94: 1,2
+            95: 1,-2
+        - node:
+            color: '#D181C7FF'
+            id: BrickTileWhiteLineE
+          decals:
+            68: -6,7
+            69: -6,8
+            70: -6,9
+            71: -7,5
+        - node:
+            color: '#EDB142FF'
+            id: BrickTileWhiteLineE
+          decals:
+            128: 10,-10
+            129: 10,-11
+            130: 10,-12
+            131: 10,-13
+            133: 11,-15
+            134: 11,-16
+        - node:
+            color: '#459909FF'
+            id: BrickTileWhiteLineN
+          decals:
+            28: 6,12
+            44: 8,11
+        - node:
+            color: '#4979AFFF'
+            id: BrickTileWhiteLineN
+          decals:
+            91: 0,5
+        - node:
+            color: '#D181C7FF'
+            id: BrickTileWhiteLineN
+          decals:
+            72: -6,12
+            73: -8,11
+        - node:
+            color: '#EDB142FF'
+            id: BrickTileWhiteLineN
+          decals:
+            142: 7,-11
+            143: 8,-11
+        - node:
+            color: '#459909FF'
+            id: BrickTileWhiteLineS
+          decals:
+            37: 9,4
+            38: 10,4
+            39: 11,4
+        - node:
+            color: '#D181C7FF'
+            id: BrickTileWhiteLineS
+          decals:
+            65: -11,4
+            66: -10,4
+            67: -9,4
+        - node:
+            color: '#EDB142FF'
+            id: BrickTileWhiteLineS
+          decals:
+            135: 10,-17
+            136: 9,-17
+            137: 8,-17
+            138: 7,-17
+            139: 6,-17
+        - node:
+            color: '#459909FF'
+            id: BrickTileWhiteLineW
+          decals:
+            24: 7,5
+            25: 6,7
+            26: 6,8
+            27: 6,9
+        - node:
+            color: '#4979AFFF'
+            id: BrickTileWhiteLineW
+          decals:
+            88: -1,3
+            89: -1,2
+            90: -1,4
+            96: -1,-2
+        - node:
+            color: '#D181C7FF'
+            id: BrickTileWhiteLineW
+          decals:
+            62: -11,6
+            63: -11,7
+            64: -10,9
+        - node:
+            color: '#EDB142FF'
+            id: BrickTileWhiteLineW
+          decals:
+            140: 4,-15
+            141: 4,-14
+        - node:
+            angle: -1.5707963267948966 rad
+            color: '#EDB142FF'
+            id: Caution
+          decals:
+            192: 11,1
+            193: 11,-1
+        - node:
+            angle: 1.5707963267948966 rad
+            color: '#EDB142FF'
+            id: Caution
+          decals:
+            194: -11,-1
+            195: -11,1
+        - node:
+            angle: -1.5707963267948966 rad
+            color: '#FFBB84FF'
+            id: Caution
+          decals:
+            207: -5,11
+        - node:
+            angle: 1.5707963267948966 rad
+            color: '#FFBB84FF'
+            id: Caution
+          decals:
+            208: 5,11
+        - node:
+            angle: 3.141592653589793 rad
+            color: '#FFBB84FF'
+            id: Caution
+          decals:
+            206: 0,-15
+        - node:
+            angle: -1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: Caution
+          decals:
+            268: -7,9
+        - node:
+            angle: 3.141592653589793 rad
+            color: '#FFFFFFFF'
+            id: Caution
+          decals:
+            269: -6,10
+        - node:
+            color: '#459909FF'
+            id: ConcreteTrimInnerNe
+          decals:
+            49: 10,8
+            50: 7,11
+        - node:
+            color: '#459909FF'
+            id: ConcreteTrimInnerSw
+          decals:
+            51: 6,10
+        - node:
+            color: '#295C05FF'
+            id: HalfTileOverlayGreyscale
+          decals:
+            116: 7,2
+            117: 8,2
+            118: 9,2
+        - node:
+            color: '#315074FF'
+            id: HalfTileOverlayGreyscale
+          decals:
+            111: 0,-5
+            112: 1,-5
+            113: 2,-5
+        - node:
+            color: '#334D6BFF'
+            id: HalfTileOverlayGreyscale
+          decals:
+            176: -1,-5
+            177: -2,-5
+        - node:
+            color: '#875381FF'
+            id: HalfTileOverlayGreyscale
+          decals:
+            196: -9,2
+        - node:
+            color: '#8A5584FF'
+            id: HalfTileOverlayGreyscale
+          decals:
+            114: -8,2
+            115: -7,2
+        - node:
+            color: '#771300FF'
+            id: HalfTileOverlayGreyscale180
+          decals:
+            171: -3,-11
+            172: -2,-11
+            173: 2,-11
+            174: 3,-11
+            180: -2,-5
+            181: 2,-5
+        - node:
+            color: '#9C752BFF'
+            id: HalfTileOverlayGreyscale180
+          decals:
+            147: 11,-8
+            148: 10,-8
+            149: 9,-8
+            150: 8,-8
+        - node:
+            color: '#771300FF'
+            id: HalfTileOverlayGreyscale270
+          decals:
+            170: -3,-11
+            178: -3,-10
+            182: -3,-6
+        - node:
+            color: '#771300FF'
+            id: HalfTileOverlayGreyscale90
+          decals:
+            175: 3,-11
+            179: 3,-10
+            183: 3,-6
+        - node:
+            color: '#8CB7E8FF'
+            id: MiniTileInnerOverlayNE
+          decals:
+            259: -9,-11
+            260: -6,-12
+            261: -5,-13
+            262: -10,-14
+            263: -8,-15
+            267: -10,-10
+        - node:
+            color: '#8CB7E8FF'
+            id: MiniTileInnerOverlayNW
+          decals:
+            264: -10,-14
+        - node:
+            color: '#8CB7E8FF'
+            id: MiniTileInnerOverlaySE
+          decals:
+            265: -5,-16
+            266: -8,-16
+        - node:
+            color: '#002F66FF'
+            id: North
+          decals:
+            209: 0,3
+        - node:
+            color: '#EDB142FF'
+            id: WarnBoxGreyscale
+          decals:
+            155: -2,-13
+            156: -2,-14
+            157: -2,-15
+            158: 2,-13
+            159: 2,-14
+            160: 2,-15
+            184: -11,-2
+            185: -11,2
+            186: -10,-2
+            187: -10,2
+            188: 11,2
+            189: 10,2
+            190: 11,-2
+            191: 10,-2
+        - node:
+            color: '#9B9B9BFF'
+            id: WarnFull
+          decals:
+            151: -13,1
+            152: -13,-1
+            153: 13,1
+            154: 13,-1
+        - node:
+            color: '#2F6A06FF'
+            id: minitile_diagonal
+          decals:
+            54: 5,12
+        - node:
+            color: '#2F6A06FF'
+            id: minitile_diagonal270
+          decals:
+            55: 5,10
+        - node:
+            color: '#2F6A06FF'
+            id: minitile_diagonal90
+          decals:
+            52: 11,8
+            53: 7,12
+        - node:
+            cleanable: True
+            angle: -0.8726646259971648 rad
+            color: '#4A2A00FF'
+            id: pawprint
+          decals:
+            23: 11.205413,-5.375915
+        - node:
+            cleanable: True
+            angle: -0.17453292519943295 rad
+            color: '#4A2A00FF'
+            id: pawprint
+          decals:
+            22: 10.802635,-6.0898814
+        - node:
+            cleanable: True
+            angle: 1.0471975511965976 rad
+            color: '#4A2A00FF'
+            id: shortline
+          decals:
+            21: 9.767913,-5.2930665
+        - node:
+            cleanable: True
+            angle: 1.5707963267948966 rad
+            color: '#4A2A00FF'
+            id: shortline
+          decals:
+            20: 11.156801,-3.6472335
+        - node:
+            cleanable: True
+            color: '#2B000089'
+            id: splatter
+          decals:
+            220: 8.037259,2.42432
+            221: 7.8636475,2.73682
+            222: 8.21087,3.1882088
+            223: 7.9157314,3.4486256
+            224: 7.950453,2.2854311
+        - node:
+            color: '#3F000084'
+            id: splatter
+          decals:
+            0: -12.258271,-3.731119
+            1: -12.355494,-5.383897
+            2: -12.265216,-3.953341
+            3: -11.654105,-3.6338968
+            4: -9.508271,-4.870008
+            5: -9.536049,-5.2936187
+        - node:
+            cleanable: True
+            color: '#4A2A00FF'
+            id: splatter
+          decals:
+            14: 11.885515,-4.1693344
+            15: 11.843849,-5.1485014
+            16: 11.836905,-4.84989
+            17: 12.32996,-5.4193344
+            18: 12.323015,-4.7179456
+            19: 11.941071,-3.7735014
+        - node:
+            cleanable: True
+            color: '#56FF008C'
+            id: splatter
+          decals:
+            167: 1.3749907,-8.943432
+            168: 0.6666572,-7.568432
+            169: -2.0625095,-8.499833
+        - node:
+            color: '#8C000084'
+            id: splatter
+          decals:
+            6: -12.558049,-3.5892582
+            7: -12.5719385,-5.554536
+            8: -9.8844385,-3.380925
+        - node:
+            cleanable: True
+            color: '#C9C9C9FF'
+            id: splatter
+          decals:
+            197: 10.996604,-3.4656546
+        - node:
+            cleanable: True
+            color: '#CC000084'
+            id: splatter
+          decals:
+            9: -11.960827,-5.283703
+        - node:
+            cleanable: True
+            color: '#E591006F'
+            id: splatter
+          decals:
+            10: 10.191071,-3.684801
+            11: 9.677182,-3.6778564
+            12: 9.670238,-4.1014676
+            13: 9.732738,-3.63619
+        - node:
+            cleanable: True
+            color: '#F9FF008C'
+            id: splatter
+          decals:
+            164: -1.3341715,-7.849682
+            165: 1.1936107,-9.662182
+            166: 2.0894442,-8.349682
+        - node:
+            cleanable: True
+            color: '#FF00008B'
+            id: splatter
+          decals:
+            214: 7.8636475,2.5111256
+            215: 7.9678144,2.1812646
+            216: 8.158787,2.702098
+            217: 7.881008,3.4486256
+            218: 8.21087,3.500709
+            219: 7.950453,2.9972367
+        - node:
+            cleanable: True
+            color: '#FFA1008C'
+            id: splatter
+          decals:
+            161: -1.2768735,-9.484165
+            162: -0.7977067,-9.494581
+            163: -1.0581235,-9.869581
+        - node:
+            cleanable: True
+            color: '#FFFFFF3E'
+            id: splatter
+          decals:
+            210: -0.041734815,-6.6260896
+            211: 0.94784844,-6.3309507
+            212: 1.2256262,-6.574006
+            213: 0.722154,-9.716367
+        - node:
+            color: '#315074FF'
+            id: tile_diagonal
+          decals:
+            107: -2,-1
+            108: 2,1
+        - node:
+            color: '#8F5889FF'
+            id: tile_diagonal
+          decals:
+            85: -5,12
+        - node:
+            color: '#315074FF'
+            id: tile_diagonal_flipped
+          decals:
+            109: -2,1
+            110: 2,-1
+        - node:
+            color: '#8F5889FF'
+            id: tile_diagonal_flipped
+          decals:
+            83: -7,12
+            84: -11,8
+            86: -5,10
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          0,0:
+            0: 13183
+            1: 32768
+          0,-1:
+            0: 29491
+            1: 136
+          -1,0:
+            0: 35022
+            1: 8193
+          0,1:
+            0: 51
+            1: 29704
+          -1,1:
+            0: 136
+            1: 50178
+          0,2:
+            1: 51217
+            2: 13056
+          -1,2:
+            2: 34816
+            1: 25089
+          0,3:
+            2: 3
+            1: 8
+          -1,3:
+            2: 8
+            1: 258
+          1,0:
+            1: 8739
+            0: 2188
+          1,2:
+            1: 1
+            0: 61064
+            3: 64
+            4: 4
+          1,3:
+            0: 14
+            1: 2304
+          1,-1:
+            1: 8977
+            0: 34828
+          1,1:
+            1: 2
+            5: 1024
+            4: 16384
+            0: 34952
+          2,0:
+            0: 7167
+            4: 1024
+          2,1:
+            0: 65527
+            4: 8
+          2,2:
+            0: 13183
+            6: 1024
+          2,-1:
+            0: 64285
+            7: 1024
+          2,3:
+            1: 32
+          3,0:
+            0: 112
+          3,1:
+            4: 17
+            1: 4
+          3,2:
+            1: 274
+          3,3:
+            1: 1
+          3,-1:
+            0: 28673
+            1: 4
+          0,-4:
+            0: 30576
+          0,-5:
+            1: 30720
+          -1,-4:
+            0: 56785
+          0,-3:
+            0: 65523
+          -1,-3:
+            0: 65512
+          0,-2:
+            0: 32767
+          -1,-2:
+            0: 53247
+          -1,-1:
+            0: 51336
+            1: 307
+          1,-4:
+            0: 65535
+          1,-3:
+            0: 61902
+          1,-2:
+            0: 61439
+          1,-5:
+            0: 57344
+            1: 64
+          2,-4:
+            0: 32767
+          2,-3:
+            0: 18039
+          2,-2:
+            0: 55807
+          2,-5:
+            0: 61440
+            1: 112
+          3,-3:
+            1: 257
+          3,-2:
+            0: 4096
+            1: 32
+          3,-4:
+            1: 546
+          3,-5:
+            1: 8208
+          -4,0:
+            0: 192
+          -4,-1:
+            0: 49152
+            1: 4
+          -4,1:
+            1: 4
+          -3,0:
+            0: 3838
+          -3,1:
+            0: 61183
+          -4,2:
+            1: 8
+          -3,-1:
+            0: 65031
+          -3,2:
+            1: 272
+            0: 36042
+            4: 4
+          -3,3:
+            1: 129
+          -2,0:
+            0: 4919
+            1: 34952
+          -2,1:
+            0: 30515
+            1: 8
+          -2,2:
+            0: 65399
+          -2,-1:
+            0: 13079
+            1: 34816
+          -2,3:
+            0: 14
+            1: 512
+          -4,-4:
+            1: 2184
+          -4,-5:
+            1: 32768
+          -4,-2:
+            1: 128
+          -3,-2:
+            0: 29422
+          -3,-4:
+            0: 52462
+            4: 512
+          -3,-3:
+            1: 257
+            0: 19660
+          -3,-5:
+            4: 8192
+            0: 49152
+            1: 208
+          -2,-4:
+            0: 65535
+          -2,-3:
+            0: 57471
+          -2,-2:
+            0: 65535
+          -2,-5:
+            0: 61440
+            1: 80
+          -1,-5:
+            1: 49664
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          immutable: True
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.14996
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.14996
+          moles:
+          - 20.078888
+          - 75.53487
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.14984
+          moles:
+          - 20.078888
+          - 75.53487
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.1499
+          moles:
+          - 20.078888
+          - 75.53487
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.1499
+          moles:
+          - 18.472576
+          - 69.49208
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: NavMap
+    - type: BecomesStation
+      id: ZaryaR
+- proto: AirAlarm
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-2.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 946
+      - 971
+      - 37
+      - 964
+      - 953
+      - 41
+      - 965
+      - 954
+      - 45
+  - uid: 5
+    components:
+    - type: Transform
+      pos: 7.5,-9.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 961
+      - 950
+      - 43
+      - 42
+      - 952
+      - 963
+      - 959
+      - 44
+      - 970
+  - uid: 6
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-9.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 38
+      - 973
+      - 947
+      - 40
+      - 949
+      - 960
+  - uid: 7
+    components:
+    - type: Transform
+      pos: -8.5,-5.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 960
+      - 40
+      - 949
+      - 39
+      - 951
+      - 962
+      - 953
+      - 41
+      - 964
+      - 963
+      - 42
+      - 952
+      - 954
+      - 965
+      - 45
+  - uid: 8
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,6.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 957
+      - 49
+      - 966
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 11.5,3.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 968
+      - 48
+      - 955
+  - uid: 10
+    components:
+    - type: Transform
+      pos: -10.5,3.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 47
+      - 956
+      - 969
+  - uid: 11
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,6.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 958
+      - 967
+      - 46
+- proto: AirCanister
+  entities:
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 4.5,-13.5
+      parent: 2
+  - uid: 13
+    components:
+    - type: Transform
+      pos: 4.5,-12.5
+      parent: 2
+- proto: AirlockEngineeringGlass
+  entities:
+  - uid: 14
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,-8.5
+      parent: 2
+- proto: AirlockExternalGlass
+  entities:
+  - uid: 15
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -11.5,1.5
+      parent: 2
+  - uid: 16
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -11.5,-0.5
+      parent: 2
+  - uid: 17
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-0.5
+      parent: 2
+  - uid: 18
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,1.5
+      parent: 2
+  - uid: 19
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,0.5
+      parent: 2
+  - uid: 20
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,0.5
+      parent: 2
+  - uid: 21
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,0.5
+      parent: 2
+  - uid: 22
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,0.5
+      parent: 2
+  - uid: 23
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-11.5
+      parent: 2
+  - uid: 24
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-11.5
+      parent: 2
+  - uid: 25
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-11.5
+      parent: 2
+- proto: AirlockGlass
+  entities:
+  - uid: 26
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-5.5
+      parent: 2
+  - uid: 27
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-2.5
+      parent: 2
+  - uid: 28
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-2.5
+      parent: 2
+- proto: AirlockGlassShuttle
+  entities:
+  - uid: 29
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -13.5,1.5
+      parent: 2
+  - uid: 30
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -13.5,-0.5
+      parent: 2
+  - uid: 31
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,1.5
+      parent: 2
+  - uid: 32
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,-0.5
+      parent: 2
+- proto: AirlockMedical
+  entities:
+  - uid: 33
+    components:
+    - type: Transform
+      pos: -9.5,-8.5
+      parent: 2
+- proto: AirlockMercenaryGlassLocked
+  entities:
+  - uid: 35
+    components:
+    - type: Transform
+      pos: -10.5,-5.5
+      parent: 2
+    - type: AccessReader
+      access:
+      - - Captain
+      - - Command
+      - - Mercenary
+- proto: AirlockMercenaryLocked
+  entities:
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 2
+    - type: AccessReader
+      access:
+      - - Captain
+      - - Command
+      - - Mercenary
+- proto: AirlockScienceGlass
+  entities:
+  - uid: 36
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 2
+- proto: AirSensor
+  entities:
+  - uid: 37
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-14.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+  - uid: 38
+    components:
+    - type: Transform
+      pos: -6.5,-13.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 6
+  - uid: 39
+    components:
+    - type: Transform
+      pos: -6.5,-6.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 7
+  - uid: 40
+    components:
+    - type: Transform
+      pos: -10.5,-3.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 6
+      - 7
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+      - 7
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 7.5,-6.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 5
+      - 7
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 12.5,-3.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 5
+  - uid: 44
+    components:
+    - type: Transform
+      pos: 8.5,-13.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 5
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+      - 7
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 8.5,9.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 11
+  - uid: 47
+    components:
+    - type: Transform
+      pos: -8.5,0.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 10
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 9
+  - uid: 49
+    components:
+    - type: Transform
+      pos: -7.5,9.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 8
+- proto: AmeController
+  entities:
+  - uid: 50
+    components:
+    - type: Transform
+      pos: 7.5,-15.5
+      parent: 2
+    - type: AmeController
+      injecting: True
+    - type: ContainerContainer
+      containers:
+        fuelSlot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 700
+- proto: AmeJar
+  entities:
+  - uid: 51
+    components:
+    - type: Transform
+      pos: 7.3428345,-12.46193
+      parent: 2
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 7.553772,-12.46193
+      parent: 2
+  - uid: 700
+    components:
+    - type: Transform
+      parent: 50
+    - type: Physics
+      canCollide: False
+- proto: AmeShielding
+  entities:
+  - uid: 53
+    components:
+    - type: Transform
+      pos: 11.5,-14.5
+      parent: 2
+  - uid: 54
+    components:
+    - type: Transform
+      pos: 11.5,-15.5
+      parent: 2
+  - uid: 55
+    components:
+    - type: Transform
+      pos: 11.5,-16.5
+      parent: 2
+  - uid: 56
+    components:
+    - type: Transform
+      pos: 10.5,-16.5
+      parent: 2
+  - uid: 57
+    components:
+    - type: Transform
+      pos: 9.5,-16.5
+      parent: 2
+  - uid: 58
+    components:
+    - type: Transform
+      pos: 8.5,-16.5
+      parent: 2
+  - uid: 59
+    components:
+    - type: Transform
+      pos: 10.5,-15.5
+      parent: 2
+    - type: PointLight
+      radius: 1
+      enabled: True
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 10.5,-14.5
+      parent: 2
+  - uid: 61
+    components:
+    - type: Transform
+      pos: 9.5,-14.5
+      parent: 2
+  - uid: 62
+    components:
+    - type: Transform
+      pos: 9.5,-15.5
+      parent: 2
+    - type: PointLight
+      radius: 1
+      enabled: True
+  - uid: 63
+    components:
+    - type: Transform
+      pos: 8.5,-15.5
+      parent: 2
+  - uid: 64
+    components:
+    - type: Transform
+      pos: 8.5,-14.5
+      parent: 2
+- proto: AnomalyCoreElectricity
+  entities:
+  - uid: 1802
+    components:
+    - type: Transform
+      pos: -8.422905,8.458323
+      parent: 2
+- proto: AnomalyScanner
+  entities:
+  - uid: 65
+    components:
+    - type: Transform
+      pos: -8.625465,11.472757
+      parent: 2
+- proto: APCBasic
+  entities:
+  - uid: 66
+    components:
+    - type: Transform
+      pos: 8.5,-9.5
+      parent: 2
+  - uid: 67
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-14.5
+      parent: 2
+  - uid: 68
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-2.5
+      parent: 2
+  - uid: 69
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,9.5
+      parent: 2
+  - uid: 70
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,9.5
+      parent: 2
+  - uid: 71
+    components:
+    - type: Transform
+      pos: -6.5,-2.5
+      parent: 2
+  - uid: 72
+    components:
+    - type: Transform
+      pos: 7.5,-2.5
+      parent: 2
+- proto: AsteroidRock
+  entities:
+  - uid: 1149
+    components:
+    - type: Transform
+      pos: 5.5,15.5
+      parent: 2
+  - uid: 1169
+    components:
+    - type: Transform
+      pos: 4.5,16.5
+      parent: 2
+  - uid: 1170
+    components:
+    - type: Transform
+      pos: 5.5,16.5
+      parent: 2
+  - uid: 1236
+    components:
+    - type: Transform
+      pos: 6.5,14.5
+      parent: 2
+  - uid: 1656
+    components:
+    - type: Transform
+      pos: 5.5,13.5
+      parent: 2
+  - uid: 1657
+    components:
+    - type: Transform
+      pos: 6.5,13.5
+      parent: 2
+  - uid: 1658
+    components:
+    - type: Transform
+      pos: 4.5,13.5
+      parent: 2
+  - uid: 1708
+    components:
+    - type: Transform
+      pos: 5.5,14.5
+      parent: 2
+  - uid: 1709
+    components:
+    - type: Transform
+      pos: 6.5,15.5
+      parent: 2
+- proto: AtmosDeviceFanTiny
+  entities:
+  - uid: 73
+    components:
+    - type: Transform
+      pos: -13.5,-0.5
+      parent: 2
+  - uid: 74
+    components:
+    - type: Transform
+      pos: 14.5,-0.5
+      parent: 2
+  - uid: 75
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 2
+  - uid: 76
+    components:
+    - type: Transform
+      pos: -13.5,1.5
+      parent: 2
+  - uid: 77
+    components:
+    - type: Transform
+      pos: 4.5,11.5
+      parent: 2
+  - uid: 78
+    components:
+    - type: Transform
+      pos: 14.5,1.5
+      parent: 2
+  - uid: 79
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 2
+  - uid: 80
+    components:
+    - type: Transform
+      pos: 1.5,-15.5
+      parent: 2
+  - uid: 81
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 2
+  - uid: 82
+    components:
+    - type: Transform
+      pos: 0.5,-15.5
+      parent: 2
+  - uid: 83
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 2
+  - uid: 84
+    components:
+    - type: Transform
+      pos: -0.5,-15.5
+      parent: 2
+  - uid: 85
+    components:
+    - type: Transform
+      pos: -3.5,11.5
+      parent: 2
+- proto: AtmosFixBlockerMarker
+  entities:
+  - uid: 86
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,6.5
+      parent: 2
+  - uid: 87
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,-11.5
+      parent: 2
+  - uid: 88
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,-9.5
+      parent: 2
+  - uid: 89
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,-13.5
+      parent: 2
+  - uid: 90
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,-14.5
+      parent: 2
+  - uid: 91
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,-15.5
+      parent: 2
+  - uid: 92
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,-16.5
+      parent: 2
+  - uid: 93
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,-18.5
+      parent: 2
+  - uid: 94
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-18.5
+      parent: 2
+  - uid: 95
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,-18.5
+      parent: 2
+  - uid: 96
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-18.5
+      parent: 2
+  - uid: 97
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-18.5
+      parent: 2
+  - uid: 98
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-17.5
+      parent: 2
+  - uid: 99
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-16.5
+      parent: 2
+  - uid: 100
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-16.5
+      parent: 2
+  - uid: 101
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-16.5
+      parent: 2
+  - uid: 102
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-16.5
+      parent: 2
+  - uid: 103
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-16.5
+      parent: 2
+  - uid: 104
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-17.5
+      parent: 2
+  - uid: 105
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-18.5
+      parent: 2
+  - uid: 106
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-18.5
+      parent: 2
+  - uid: 107
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-18.5
+      parent: 2
+  - uid: 108
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,12.5
+      parent: 2
+  - uid: 109
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-18.5
+      parent: 2
+  - uid: 110
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-18.5
+      parent: 2
+  - uid: 111
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-16.5
+      parent: 2
+  - uid: 112
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-15.5
+      parent: 2
+  - uid: 113
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-14.5
+      parent: 2
+  - uid: 114
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-13.5
+      parent: 2
+  - uid: 115
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-11.5
+      parent: 2
+  - uid: 116
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-9.5
+      parent: 2
+  - uid: 117
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-6.5
+      parent: 2
+  - uid: 118
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-3.5
+      parent: 2
+  - uid: 119
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,4.5
+      parent: 2
+  - uid: 120
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,8.5
+      parent: 2
+  - uid: 121
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,12.5
+      parent: 2
+  - uid: 122
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,13.5
+      parent: 2
+  - uid: 123
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,14.5
+      parent: 2
+  - uid: 124
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,14.5
+      parent: 2
+  - uid: 125
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,10.5
+      parent: 2
+  - uid: 126
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,11.5
+      parent: 2
+  - uid: 127
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,11.5
+      parent: 2
+  - uid: 128
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,11.5
+      parent: 2
+  - uid: 129
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,12.5
+      parent: 2
+  - uid: 130
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,12.5
+      parent: 2
+  - uid: 131
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,11.5
+      parent: 2
+  - uid: 132
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,10.5
+      parent: 2
+  - uid: 133
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,10.5
+      parent: 2
+  - uid: 134
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,10.5
+      parent: 2
+  - uid: 135
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,11.5
+      parent: 2
+  - uid: 136
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,12.5
+      parent: 2
+  - uid: 137
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,11.5
+      parent: 2
+  - uid: 138
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,11.5
+      parent: 2
+  - uid: 139
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,12.5
+      parent: 2
+  - uid: 140
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,10.5
+      parent: 2
+  - uid: 141
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,8.5
+      parent: 2
+  - uid: 142
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,7.5
+      parent: 2
+  - uid: 143
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,7.5
+      parent: 2
+  - uid: 144
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,7.5
+      parent: 2
+  - uid: 145
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,8.5
+      parent: 2
+  - uid: 146
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,9.5
+      parent: 2
+  - uid: 147
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,4.5
+      parent: 2
+  - uid: 148
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,7.5
+      parent: 2
+  - uid: 149
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,7.5
+      parent: 2
+  - uid: 150
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,6.5
+      parent: 2
+  - uid: 151
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,8.5
+      parent: 2
+  - uid: 152
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,4.5
+      parent: 2
+  - uid: 153
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,3.5
+      parent: 2
+  - uid: 154
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,2.5
+      parent: 2
+  - uid: 155
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,1.5
+      parent: 2
+  - uid: 156
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,0.5
+      parent: 2
+  - uid: 157
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,0.5
+      parent: 2
+  - uid: 158
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-0.5
+      parent: 2
+  - uid: 159
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-1.5
+      parent: 2
+  - uid: 160
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-1.5
+      parent: 2
+  - uid: 161
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-2.5
+      parent: 2
+  - uid: 162
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-2.5
+      parent: 2
+  - uid: 163
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-3.5
+      parent: 2
+  - uid: 164
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-3.5
+      parent: 2
+  - uid: 165
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,4.5
+      parent: 2
+  - uid: 166
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,3.5
+      parent: 2
+  - uid: 167
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,4.5
+      parent: 2
+  - uid: 168
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,3.5
+      parent: 2
+  - uid: 169
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,3.5
+      parent: 2
+  - uid: 170
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,2.5
+      parent: 2
+  - uid: 171
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,0.5
+      parent: 2
+  - uid: 172
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,-3.5
+      parent: 2
+  - uid: 173
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,1.5
+      parent: 2
+  - uid: 174
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,0.5
+      parent: 2
+  - uid: 175
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-0.5
+      parent: 2
+  - uid: 176
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-1.5
+      parent: 2
+  - uid: 177
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-1.5
+      parent: 2
+  - uid: 178
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-2.5
+      parent: 2
+  - uid: 179
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-3.5
+      parent: 2
+  - uid: 180
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-3.5
+      parent: 2
+  - uid: 181
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-2.5
+      parent: 2
+  - uid: 182
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,14.5
+      parent: 2
+  - uid: 183
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,14.5
+      parent: 2
+  - uid: 184
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,13.5
+      parent: 2
+  - uid: 185
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,12.5
+      parent: 2
+  - uid: 186
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,10.5
+      parent: 2
+  - uid: 187
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,9.5
+      parent: 2
+  - uid: 188
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,8.5
+      parent: 2
+  - uid: 189
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,4.5
+      parent: 2
+  - uid: 190
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,-6.5
+      parent: 2
+  - uid: 194
+    components:
+    - type: Transform
+      pos: 4.5,-0.5
+      parent: 2
+  - uid: 698
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,9.5
+      parent: 2
+  - uid: 1018
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 2
+  - uid: 1741
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,10.5
+      parent: 2
+- proto: Autolathe
+  entities:
+  - uid: 1304
+    components:
+    - type: Transform
+      pos: -5.5,6.5
+      parent: 2
+- proto: BarricadeBlock
+  entities:
+  - uid: 192
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,3.5
+      parent: 2
+  - uid: 1168
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-8.5
+      parent: 2
+- proto: BarricadeDirectional
+  entities:
+  - uid: 195
+    components:
+    - type: Transform
+      pos: -9.5,-7.5
+      parent: 2
+  - uid: 196
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,11.5
+      parent: 2
+  - uid: 197
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,11.5
+      parent: 2
+- proto: BlastDoor
+  entities:
+  - uid: 199
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,11.5
+      parent: 2
+  - uid: 200
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-15.5
+      parent: 2
+  - uid: 201
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-15.5
+      parent: 2
+  - uid: 202
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-15.5
+      parent: 2
+  - uid: 203
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,11.5
+      parent: 2
+  - uid: 1673
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,11.5
+      parent: 2
+  - uid: 1674
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,11.5
+      parent: 2
+- proto: BlastDoorOpen
+  entities:
+  - uid: 204
+    components:
+    - type: Transform
+      pos: -12.5,-0.5
+      parent: 2
+  - uid: 205
+    components:
+    - type: Transform
+      pos: -12.5,1.5
+      parent: 2
+  - uid: 206
+    components:
+    - type: Transform
+      pos: 13.5,1.5
+      parent: 2
+  - uid: 207
+    components:
+    - type: Transform
+      pos: 13.5,-0.5
+      parent: 2
+- proto: BoxBeanbag
+  entities:
+  - uid: 1740
+    components:
+    - type: Transform
+      parent: 1772
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: BoxFolderBlue
+  entities:
+  - uid: 755
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.626768,6.6591434
+      parent: 2
+- proto: BoxFolderRed
+  entities:
+  - uid: 1144
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.658018,7.2997684
+      parent: 2
+- proto: BoxFolderWhite
+  entities:
+  - uid: 1311
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.345518,6.9560184
+      parent: 2
+- proto: BoxHandcuff
+  entities:
+  - uid: 209
+    components:
+    - type: Transform
+      pos: 9.662808,4.682262
+      parent: 2
+- proto: BoxLethalshot
+  entities:
+  - uid: 1238
+    components:
+    - type: Transform
+      parent: 1772
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1736
+    components:
+    - type: Transform
+      parent: 1771
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: BoxShotgunFlare
+  entities:
+  - uid: 662
+    components:
+    - type: Transform
+      parent: 1774
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: BoxShotgunSlug
+  entities:
+  - uid: 1742
+    components:
+    - type: Transform
+      parent: 1771
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: BoxZiptie
+  entities:
+  - uid: 1734
+    components:
+    - type: Transform
+      pos: 9.31488,4.338512
+      parent: 2
+- proto: ButtonFrameCautionSecurity
+  entities:
+  - uid: 210
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 2
+  - uid: 211
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 2
+- proto: CableApcExtension
+  entities:
+  - uid: 212
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 2
+  - uid: 213
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 2
+  - uid: 214
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 2
+  - uid: 215
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 2
+  - uid: 216
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 2
+  - uid: 217
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 2
+  - uid: 218
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 2
+  - uid: 219
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 2
+  - uid: 220
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 2
+  - uid: 221
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 2
+  - uid: 222
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 2
+  - uid: 223
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 2
+  - uid: 224
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 2
+  - uid: 225
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 2
+  - uid: 226
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 2
+  - uid: 227
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 2
+  - uid: 228
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 2
+  - uid: 229
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 2
+  - uid: 230
+    components:
+    - type: Transform
+      pos: 5.5,9.5
+      parent: 2
+  - uid: 231
+    components:
+    - type: Transform
+      pos: 6.5,9.5
+      parent: 2
+  - uid: 232
+    components:
+    - type: Transform
+      pos: 8.5,-10.5
+      parent: 2
+  - uid: 233
+    components:
+    - type: Transform
+      pos: 8.5,9.5
+      parent: 2
+  - uid: 234
+    components:
+    - type: Transform
+      pos: 9.5,9.5
+      parent: 2
+  - uid: 235
+    components:
+    - type: Transform
+      pos: 10.5,9.5
+      parent: 2
+  - uid: 236
+    components:
+    - type: Transform
+      pos: 7.5,9.5
+      parent: 2
+  - uid: 237
+    components:
+    - type: Transform
+      pos: 7.5,8.5
+      parent: 2
+  - uid: 238
+    components:
+    - type: Transform
+      pos: 7.5,7.5
+      parent: 2
+  - uid: 239
+    components:
+    - type: Transform
+      pos: 7.5,6.5
+      parent: 2
+  - uid: 240
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 2
+  - uid: 241
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 2
+  - uid: 242
+    components:
+    - type: Transform
+      pos: 9.5,5.5
+      parent: 2
+  - uid: 243
+    components:
+    - type: Transform
+      pos: 10.5,5.5
+      parent: 2
+  - uid: 244
+    components:
+    - type: Transform
+      pos: 11.5,5.5
+      parent: 2
+  - uid: 245
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 2
+  - uid: 246
+    components:
+    - type: Transform
+      pos: -5.5,9.5
+      parent: 2
+  - uid: 247
+    components:
+    - type: Transform
+      pos: -6.5,9.5
+      parent: 2
+  - uid: 248
+    components:
+    - type: Transform
+      pos: -7.5,9.5
+      parent: 2
+  - uid: 249
+    components:
+    - type: Transform
+      pos: -8.5,9.5
+      parent: 2
+  - uid: 250
+    components:
+    - type: Transform
+      pos: -9.5,9.5
+      parent: 2
+  - uid: 251
+    components:
+    - type: Transform
+      pos: 7.5,10.5
+      parent: 2
+  - uid: 252
+    components:
+    - type: Transform
+      pos: 7.5,11.5
+      parent: 2
+  - uid: 253
+    components:
+    - type: Transform
+      pos: -6.5,10.5
+      parent: 2
+  - uid: 254
+    components:
+    - type: Transform
+      pos: -6.5,11.5
+      parent: 2
+  - uid: 255
+    components:
+    - type: Transform
+      pos: -7.5,8.5
+      parent: 2
+  - uid: 256
+    components:
+    - type: Transform
+      pos: -7.5,7.5
+      parent: 2
+  - uid: 257
+    components:
+    - type: Transform
+      pos: -7.5,6.5
+      parent: 2
+  - uid: 258
+    components:
+    - type: Transform
+      pos: -7.5,5.5
+      parent: 2
+  - uid: 259
+    components:
+    - type: Transform
+      pos: -7.5,4.5
+      parent: 2
+  - uid: 260
+    components:
+    - type: Transform
+      pos: -8.5,6.5
+      parent: 2
+  - uid: 261
+    components:
+    - type: Transform
+      pos: -9.5,6.5
+      parent: 2
+  - uid: 262
+    components:
+    - type: Transform
+      pos: -9.5,5.5
+      parent: 2
+  - uid: 263
+    components:
+    - type: Transform
+      pos: -10.5,5.5
+      parent: 2
+  - uid: 264
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 2
+  - uid: 265
+    components:
+    - type: Transform
+      pos: -6.5,-2.5
+      parent: 2
+  - uid: 266
+    components:
+    - type: Transform
+      pos: -6.5,-3.5
+      parent: 2
+  - uid: 267
+    components:
+    - type: Transform
+      pos: -6.5,-4.5
+      parent: 2
+  - uid: 268
+    components:
+    - type: Transform
+      pos: 8.5,-11.5
+      parent: 2
+  - uid: 269
+    components:
+    - type: Transform
+      pos: -6.5,-5.5
+      parent: 2
+  - uid: 270
+    components:
+    - type: Transform
+      pos: -5.5,-5.5
+      parent: 2
+  - uid: 271
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 2
+  - uid: 272
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 2
+  - uid: 273
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 2
+  - uid: 274
+    components:
+    - type: Transform
+      pos: 8.5,-9.5
+      parent: 2
+  - uid: 275
+    components:
+    - type: Transform
+      pos: -7.5,-5.5
+      parent: 2
+  - uid: 276
+    components:
+    - type: Transform
+      pos: -7.5,-6.5
+      parent: 2
+  - uid: 277
+    components:
+    - type: Transform
+      pos: -8.5,-6.5
+      parent: 2
+  - uid: 278
+    components:
+    - type: Transform
+      pos: -11.5,-0.5
+      parent: 2
+  - uid: 279
+    components:
+    - type: Transform
+      pos: -9.5,-6.5
+      parent: 2
+  - uid: 280
+    components:
+    - type: Transform
+      pos: -10.5,-6.5
+      parent: 2
+  - uid: 281
+    components:
+    - type: Transform
+      pos: -10.5,-5.5
+      parent: 2
+  - uid: 282
+    components:
+    - type: Transform
+      pos: -10.5,-4.5
+      parent: 2
+  - uid: 283
+    components:
+    - type: Transform
+      pos: 7.5,-2.5
+      parent: 2
+  - uid: 284
+    components:
+    - type: Transform
+      pos: 7.5,-3.5
+      parent: 2
+  - uid: 285
+    components:
+    - type: Transform
+      pos: 8.5,-3.5
+      parent: 2
+  - uid: 286
+    components:
+    - type: Transform
+      pos: 8.5,-4.5
+      parent: 2
+  - uid: 287
+    components:
+    - type: Transform
+      pos: 8.5,-5.5
+      parent: 2
+  - uid: 288
+    components:
+    - type: Transform
+      pos: 7.5,-5.5
+      parent: 2
+  - uid: 289
+    components:
+    - type: Transform
+      pos: 6.5,-5.5
+      parent: 2
+  - uid: 290
+    components:
+    - type: Transform
+      pos: 5.5,-5.5
+      parent: 2
+  - uid: 291
+    components:
+    - type: Transform
+      pos: 4.5,-5.5
+      parent: 2
+  - uid: 292
+    components:
+    - type: Transform
+      pos: 3.5,-5.5
+      parent: 2
+  - uid: 293
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
+      parent: 2
+  - uid: 294
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 2
+  - uid: 295
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 2
+  - uid: 296
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 2
+  - uid: 297
+    components:
+    - type: Transform
+      pos: -1.5,-8.5
+      parent: 2
+  - uid: 298
+    components:
+    - type: Transform
+      pos: -1.5,-9.5
+      parent: 2
+  - uid: 299
+    components:
+    - type: Transform
+      pos: -1.5,-10.5
+      parent: 2
+  - uid: 300
+    components:
+    - type: Transform
+      pos: -1.5,-11.5
+      parent: 2
+  - uid: 301
+    components:
+    - type: Transform
+      pos: -1.5,-12.5
+      parent: 2
+  - uid: 302
+    components:
+    - type: Transform
+      pos: -1.5,-13.5
+      parent: 2
+  - uid: 303
+    components:
+    - type: Transform
+      pos: -1.5,-14.5
+      parent: 2
+  - uid: 304
+    components:
+    - type: Transform
+      pos: 2.5,-6.5
+      parent: 2
+  - uid: 305
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 2
+  - uid: 306
+    components:
+    - type: Transform
+      pos: 2.5,-8.5
+      parent: 2
+  - uid: 307
+    components:
+    - type: Transform
+      pos: 2.5,-9.5
+      parent: 2
+  - uid: 308
+    components:
+    - type: Transform
+      pos: 2.5,-10.5
+      parent: 2
+  - uid: 309
+    components:
+    - type: Transform
+      pos: 2.5,-11.5
+      parent: 2
+  - uid: 310
+    components:
+    - type: Transform
+      pos: 2.5,-12.5
+      parent: 2
+  - uid: 311
+    components:
+    - type: Transform
+      pos: 2.5,-13.5
+      parent: 2
+  - uid: 312
+    components:
+    - type: Transform
+      pos: 2.5,-14.5
+      parent: 2
+  - uid: 313
+    components:
+    - type: Transform
+      pos: 8.5,-12.5
+      parent: 2
+  - uid: 314
+    components:
+    - type: Transform
+      pos: 9.5,-12.5
+      parent: 2
+  - uid: 315
+    components:
+    - type: Transform
+      pos: 10.5,-12.5
+      parent: 2
+  - uid: 316
+    components:
+    - type: Transform
+      pos: 10.5,-11.5
+      parent: 2
+  - uid: 317
+    components:
+    - type: Transform
+      pos: 10.5,-10.5
+      parent: 2
+  - uid: 318
+    components:
+    - type: Transform
+      pos: 10.5,-9.5
+      parent: 2
+  - uid: 319
+    components:
+    - type: Transform
+      pos: 10.5,-8.5
+      parent: 2
+  - uid: 320
+    components:
+    - type: Transform
+      pos: 7.5,-7.5
+      parent: 2
+  - uid: 321
+    components:
+    - type: Transform
+      pos: 4.5,-7.5
+      parent: 2
+  - uid: 322
+    components:
+    - type: Transform
+      pos: 8.5,-7.5
+      parent: 2
+  - uid: 323
+    components:
+    - type: Transform
+      pos: 7.5,-12.5
+      parent: 2
+  - uid: 324
+    components:
+    - type: Transform
+      pos: 6.5,-12.5
+      parent: 2
+  - uid: 325
+    components:
+    - type: Transform
+      pos: 5.5,-12.5
+      parent: 2
+  - uid: 326
+    components:
+    - type: Transform
+      pos: 5.5,-13.5
+      parent: 2
+  - uid: 327
+    components:
+    - type: Transform
+      pos: 5.5,-14.5
+      parent: 2
+  - uid: 328
+    components:
+    - type: Transform
+      pos: 5.5,-15.5
+      parent: 2
+  - uid: 329
+    components:
+    - type: Transform
+      pos: 8.5,-13.5
+      parent: 2
+  - uid: 330
+    components:
+    - type: Transform
+      pos: 8.5,-14.5
+      parent: 2
+  - uid: 331
+    components:
+    - type: Transform
+      pos: 8.5,-15.5
+      parent: 2
+  - uid: 332
+    components:
+    - type: Transform
+      pos: 8.5,-16.5
+      parent: 2
+  - uid: 333
+    components:
+    - type: Transform
+      pos: 8.5,-17.5
+      parent: 2
+  - uid: 334
+    components:
+    - type: Transform
+      pos: 9.5,-17.5
+      parent: 2
+  - uid: 335
+    components:
+    - type: Transform
+      pos: -11.5,-14.5
+      parent: 2
+  - uid: 336
+    components:
+    - type: Transform
+      pos: -10.5,-14.5
+      parent: 2
+  - uid: 337
+    components:
+    - type: Transform
+      pos: -9.5,-14.5
+      parent: 2
+  - uid: 338
+    components:
+    - type: Transform
+      pos: -9.5,-14.5
+      parent: 2
+  - uid: 339
+    components:
+    - type: Transform
+      pos: -9.5,-15.5
+      parent: 2
+  - uid: 340
+    components:
+    - type: Transform
+      pos: -9.5,-16.5
+      parent: 2
+  - uid: 341
+    components:
+    - type: Transform
+      pos: -9.5,-17.5
+      parent: 2
+  - uid: 342
+    components:
+    - type: Transform
+      pos: -8.5,-17.5
+      parent: 2
+  - uid: 343
+    components:
+    - type: Transform
+      pos: -9.5,-13.5
+      parent: 2
+  - uid: 344
+    components:
+    - type: Transform
+      pos: -9.5,-12.5
+      parent: 2
+  - uid: 346
+    components:
+    - type: Transform
+      pos: -2.5,11.5
+      parent: 2
+  - uid: 347
+    components:
+    - type: Transform
+      pos: -8.5,-10.5
+      parent: 2
+  - uid: 348
+    components:
+    - type: Transform
+      pos: -7.5,-10.5
+      parent: 2
+  - uid: 349
+    components:
+    - type: Transform
+      pos: -6.5,-10.5
+      parent: 2
+  - uid: 350
+    components:
+    - type: Transform
+      pos: -5.5,-10.5
+      parent: 2
+  - uid: 351
+    components:
+    - type: Transform
+      pos: -5.5,-11.5
+      parent: 2
+  - uid: 352
+    components:
+    - type: Transform
+      pos: -5.5,-12.5
+      parent: 2
+  - uid: 353
+    components:
+    - type: Transform
+      pos: -5.5,-13.5
+      parent: 2
+  - uid: 354
+    components:
+    - type: Transform
+      pos: -5.5,-14.5
+      parent: 2
+  - uid: 355
+    components:
+    - type: Transform
+      pos: -5.5,-15.5
+      parent: 2
+  - uid: 356
+    components:
+    - type: Transform
+      pos: -5.5,-16.5
+      parent: 2
+  - uid: 357
+    components:
+    - type: Transform
+      pos: -7.5,-7.5
+      parent: 2
+  - uid: 358
+    components:
+    - type: Transform
+      pos: -6.5,-7.5
+      parent: 2
+  - uid: 359
+    components:
+    - type: Transform
+      pos: -5.5,-7.5
+      parent: 2
+  - uid: 360
+    components:
+    - type: Transform
+      pos: -4.5,-7.5
+      parent: 2
+  - uid: 361
+    components:
+    - type: Transform
+      pos: 8.5,-6.5
+      parent: 2
+  - uid: 362
+    components:
+    - type: Transform
+      pos: 8.5,-7.5
+      parent: 2
+  - uid: 363
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 2
+  - uid: 364
+    components:
+    - type: Transform
+      pos: -9.5,-8.5
+      parent: 2
+  - uid: 365
+    components:
+    - type: Transform
+      pos: -9.5,-9.5
+      parent: 2
+  - uid: 366
+    components:
+    - type: Transform
+      pos: 6.5,-7.5
+      parent: 2
+  - uid: 367
+    components:
+    - type: Transform
+      pos: 5.5,-7.5
+      parent: 2
+  - uid: 368
+    components:
+    - type: Transform
+      pos: -7.5,2.5
+      parent: 2
+  - uid: 369
+    components:
+    - type: Transform
+      pos: -7.5,1.5
+      parent: 2
+  - uid: 370
+    components:
+    - type: Transform
+      pos: -7.5,0.5
+      parent: 2
+  - uid: 371
+    components:
+    - type: Transform
+      pos: 8.5,4.5
+      parent: 2
+  - uid: 372
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 2
+  - uid: 373
+    components:
+    - type: Transform
+      pos: 8.5,2.5
+      parent: 2
+  - uid: 374
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 2
+  - uid: 375
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 2
+  - uid: 376
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 2
+  - uid: 377
+    components:
+    - type: Transform
+      pos: 10.5,0.5
+      parent: 2
+  - uid: 378
+    components:
+    - type: Transform
+      pos: 11.5,0.5
+      parent: 2
+  - uid: 379
+    components:
+    - type: Transform
+      pos: 11.5,1.5
+      parent: 2
+  - uid: 380
+    components:
+    - type: Transform
+      pos: 11.5,-0.5
+      parent: 2
+  - uid: 381
+    components:
+    - type: Transform
+      pos: 12.5,1.5
+      parent: 2
+  - uid: 382
+    components:
+    - type: Transform
+      pos: 12.5,-0.5
+      parent: 2
+  - uid: 383
+    components:
+    - type: Transform
+      pos: -8.5,0.5
+      parent: 2
+  - uid: 384
+    components:
+    - type: Transform
+      pos: -9.5,0.5
+      parent: 2
+  - uid: 385
+    components:
+    - type: Transform
+      pos: -10.5,0.5
+      parent: 2
+  - uid: 386
+    components:
+    - type: Transform
+      pos: -10.5,1.5
+      parent: 2
+  - uid: 387
+    components:
+    - type: Transform
+      pos: -10.5,-0.5
+      parent: 2
+  - uid: 388
+    components:
+    - type: Transform
+      pos: -5.5,11.5
+      parent: 2
+  - uid: 389
+    components:
+    - type: Transform
+      pos: -11.5,1.5
+      parent: 2
+  - uid: 390
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 2
+  - uid: 391
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 2
+  - uid: 392
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 2
+  - uid: 393
+    components:
+    - type: Transform
+      pos: 6.5,-0.5
+      parent: 2
+  - uid: 394
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 2
+  - uid: 395
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 2
+  - uid: 396
+    components:
+    - type: Transform
+      pos: -4.5,11.5
+      parent: 2
+  - uid: 397
+    components:
+    - type: Transform
+      pos: 6.5,11.5
+      parent: 2
+  - uid: 398
+    components:
+    - type: Transform
+      pos: 5.5,11.5
+      parent: 2
+  - uid: 399
+    components:
+    - type: Transform
+      pos: -3.5,11.5
+      parent: 2
+  - uid: 400
+    components:
+    - type: Transform
+      pos: 4.5,11.5
+      parent: 2
+  - uid: 401
+    components:
+    - type: Transform
+      pos: -1.5,11.5
+      parent: 2
+  - uid: 402
+    components:
+    - type: Transform
+      pos: 10.5,-13.5
+      parent: 2
+  - uid: 403
+    components:
+    - type: Transform
+      pos: 11.5,-13.5
+      parent: 2
+  - uid: 404
+    components:
+    - type: Transform
+      pos: 12.5,-13.5
+      parent: 2
+  - uid: 405
+    components:
+    - type: Transform
+      pos: 12.5,-14.5
+      parent: 2
+  - uid: 406
+    components:
+    - type: Transform
+      pos: 12.5,-15.5
+      parent: 2
+  - uid: 407
+    components:
+    - type: Transform
+      pos: 3.5,11.5
+      parent: 2
+  - uid: 1011
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 2
+  - uid: 1781
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 2
+- proto: CableApcStack1
+  entities:
+  - uid: 191
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.469639,-14.147763
+      parent: 2
+  - uid: 208
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.605055,-12.366513
+      parent: 2
+  - uid: 409
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5282698,11.464497
+      parent: 2
+  - uid: 985
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.188389,-14.637347
+      parent: 2
+- proto: CableHV
+  entities:
+  - uid: 410
+    components:
+    - type: Transform
+      pos: 9.5,-7.5
+      parent: 2
+  - uid: 411
+    components:
+    - type: Transform
+      pos: 7.5,-15.5
+      parent: 2
+  - uid: 412
+    components:
+    - type: Transform
+      pos: 6.5,-15.5
+      parent: 2
+  - uid: 413
+    components:
+    - type: Transform
+      pos: 5.5,-15.5
+      parent: 2
+  - uid: 414
+    components:
+    - type: Transform
+      pos: 5.5,-14.5
+      parent: 2
+  - uid: 415
+    components:
+    - type: Transform
+      pos: 5.5,-16.5
+      parent: 2
+  - uid: 416
+    components:
+    - type: Transform
+      pos: 4.5,-16.5
+      parent: 2
+  - uid: 417
+    components:
+    - type: Transform
+      pos: 4.5,-15.5
+      parent: 2
+  - uid: 418
+    components:
+    - type: Transform
+      pos: 4.5,-14.5
+      parent: 2
+  - uid: 419
+    components:
+    - type: Transform
+      pos: 4.5,-13.5
+      parent: 2
+  - uid: 420
+    components:
+    - type: Transform
+      pos: 4.5,-12.5
+      parent: 2
+  - uid: 421
+    components:
+    - type: Transform
+      pos: 5.5,-12.5
+      parent: 2
+  - uid: 422
+    components:
+    - type: Transform
+      pos: 6.5,-12.5
+      parent: 2
+  - uid: 423
+    components:
+    - type: Transform
+      pos: 7.5,-12.5
+      parent: 2
+  - uid: 424
+    components:
+    - type: Transform
+      pos: 8.5,-12.5
+      parent: 2
+  - uid: 425
+    components:
+    - type: Transform
+      pos: 9.5,-12.5
+      parent: 2
+  - uid: 426
+    components:
+    - type: Transform
+      pos: 10.5,-12.5
+      parent: 2
+  - uid: 427
+    components:
+    - type: Transform
+      pos: 10.5,-10.5
+      parent: 2
+  - uid: 428
+    components:
+    - type: Transform
+      pos: 10.5,-9.5
+      parent: 2
+  - uid: 429
+    components:
+    - type: Transform
+      pos: 10.5,-8.5
+      parent: 2
+  - uid: 430
+    components:
+    - type: Transform
+      pos: 10.5,-7.5
+      parent: 2
+  - uid: 431
+    components:
+    - type: Transform
+      pos: 8.5,-7.5
+      parent: 2
+  - uid: 432
+    components:
+    - type: Transform
+      pos: 7.5,-7.5
+      parent: 2
+  - uid: 433
+    components:
+    - type: Transform
+      pos: 8.5,-6.5
+      parent: 2
+  - uid: 434
+    components:
+    - type: Transform
+      pos: 8.5,-5.5
+      parent: 2
+  - uid: 435
+    components:
+    - type: Transform
+      pos: 8.5,-4.5
+      parent: 2
+  - uid: 436
+    components:
+    - type: Transform
+      pos: 8.5,-3.5
+      parent: 2
+  - uid: 437
+    components:
+    - type: Transform
+      pos: 8.5,-2.5
+      parent: 2
+  - uid: 438
+    components:
+    - type: Transform
+      pos: 8.5,-1.5
+      parent: 2
+  - uid: 439
+    components:
+    - type: Transform
+      pos: 8.5,-0.5
+      parent: 2
+  - uid: 440
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 2
+  - uid: 441
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 2
+  - uid: 442
+    components:
+    - type: Transform
+      pos: 8.5,2.5
+      parent: 2
+  - uid: 443
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 2
+  - uid: 444
+    components:
+    - type: Transform
+      pos: 8.5,4.5
+      parent: 2
+  - uid: 445
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 2
+  - uid: 446
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 2
+  - uid: 447
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 2
+  - uid: 448
+    components:
+    - type: Transform
+      pos: 6.5,-7.5
+      parent: 2
+  - uid: 449
+    components:
+    - type: Transform
+      pos: 5.5,-7.5
+      parent: 2
+  - uid: 450
+    components:
+    - type: Transform
+      pos: 4.5,-7.5
+      parent: 2
+  - uid: 451
+    components:
+    - type: Transform
+      pos: 3.5,-7.5
+      parent: 2
+  - uid: 452
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 2
+  - uid: 453
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 2
+  - uid: 454
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 2
+  - uid: 455
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 2
+  - uid: 456
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 2
+  - uid: 457
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 2
+  - uid: 458
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 2
+  - uid: 459
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 2
+  - uid: 460
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 2
+  - uid: 461
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 2
+  - uid: 462
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 2
+  - uid: 463
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 2
+  - uid: 464
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 2
+  - uid: 465
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 2
+  - uid: 466
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 2
+  - uid: 467
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 2
+  - uid: 468
+    components:
+    - type: Transform
+      pos: -0.5,-7.5
+      parent: 2
+  - uid: 469
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 2
+  - uid: 470
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 2
+  - uid: 471
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 2
+  - uid: 472
+    components:
+    - type: Transform
+      pos: -4.5,-7.5
+      parent: 2
+  - uid: 473
+    components:
+    - type: Transform
+      pos: -5.5,-7.5
+      parent: 2
+  - uid: 474
+    components:
+    - type: Transform
+      pos: -6.5,-7.5
+      parent: 2
+  - uid: 475
+    components:
+    - type: Transform
+      pos: -7.5,-7.5
+      parent: 2
+  - uid: 476
+    components:
+    - type: Transform
+      pos: -7.5,-7.5
+      parent: 2
+  - uid: 477
+    components:
+    - type: Transform
+      pos: -7.5,-6.5
+      parent: 2
+  - uid: 478
+    components:
+    - type: Transform
+      pos: -7.5,-5.5
+      parent: 2
+  - uid: 479
+    components:
+    - type: Transform
+      pos: -7.5,-4.5
+      parent: 2
+  - uid: 480
+    components:
+    - type: Transform
+      pos: -7.5,-3.5
+      parent: 2
+  - uid: 481
+    components:
+    - type: Transform
+      pos: -7.5,-2.5
+      parent: 2
+  - uid: 482
+    components:
+    - type: Transform
+      pos: -7.5,-1.5
+      parent: 2
+  - uid: 483
+    components:
+    - type: Transform
+      pos: -7.5,-0.5
+      parent: 2
+  - uid: 484
+    components:
+    - type: Transform
+      pos: -7.5,0.5
+      parent: 2
+  - uid: 485
+    components:
+    - type: Transform
+      pos: -7.5,1.5
+      parent: 2
+  - uid: 486
+    components:
+    - type: Transform
+      pos: -7.5,2.5
+      parent: 2
+  - uid: 487
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 2
+  - uid: 488
+    components:
+    - type: Transform
+      pos: -7.5,4.5
+      parent: 2
+  - uid: 489
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 2
+  - uid: 490
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 2
+  - uid: 491
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 2
+  - uid: 492
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 2
+  - uid: 493
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 2
+  - uid: 494
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 2
+  - uid: 495
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 2
+  - uid: 496
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 2
+  - uid: 497
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 2
+  - uid: 498
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 2
+  - uid: 499
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 2
+  - uid: 500
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 2
+  - uid: 501
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 2
+  - uid: 502
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 2
+  - uid: 503
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 2
+  - uid: 504
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 2
+  - uid: 505
+    components:
+    - type: Transform
+      pos: 10.5,-11.5
+      parent: 2
+- proto: CableMV
+  entities:
+  - uid: 506
+    components:
+    - type: Transform
+      pos: 5.5,-12.5
+      parent: 2
+  - uid: 507
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 2
+  - uid: 508
+    components:
+    - type: Transform
+      pos: 10.5,-10.5
+      parent: 2
+  - uid: 509
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 2
+  - uid: 510
+    components:
+    - type: Transform
+      pos: 5.5,-16.5
+      parent: 2
+  - uid: 511
+    components:
+    - type: Transform
+      pos: 5.5,-15.5
+      parent: 2
+  - uid: 512
+    components:
+    - type: Transform
+      pos: 5.5,-14.5
+      parent: 2
+  - uid: 513
+    components:
+    - type: Transform
+      pos: 5.5,-13.5
+      parent: 2
+  - uid: 514
+    components:
+    - type: Transform
+      pos: 5.5,-12.5
+      parent: 2
+  - uid: 515
+    components:
+    - type: Transform
+      pos: 6.5,-12.5
+      parent: 2
+  - uid: 516
+    components:
+    - type: Transform
+      pos: 7.5,-12.5
+      parent: 2
+  - uid: 517
+    components:
+    - type: Transform
+      pos: 8.5,-12.5
+      parent: 2
+  - uid: 518
+    components:
+    - type: Transform
+      pos: 9.5,-12.5
+      parent: 2
+  - uid: 519
+    components:
+    - type: Transform
+      pos: 10.5,-12.5
+      parent: 2
+  - uid: 520
+    components:
+    - type: Transform
+      pos: 10.5,-11.5
+      parent: 2
+  - uid: 521
+    components:
+    - type: Transform
+      pos: 8.5,-12.5
+      parent: 2
+  - uid: 522
+    components:
+    - type: Transform
+      pos: 8.5,-11.5
+      parent: 2
+  - uid: 523
+    components:
+    - type: Transform
+      pos: 8.5,-10.5
+      parent: 2
+  - uid: 524
+    components:
+    - type: Transform
+      pos: 8.5,-9.5
+      parent: 2
+  - uid: 525
+    components:
+    - type: Transform
+      pos: 10.5,-9.5
+      parent: 2
+  - uid: 526
+    components:
+    - type: Transform
+      pos: 10.5,-8.5
+      parent: 2
+  - uid: 527
+    components:
+    - type: Transform
+      pos: 10.5,-7.5
+      parent: 2
+  - uid: 528
+    components:
+    - type: Transform
+      pos: 9.5,-7.5
+      parent: 2
+  - uid: 529
+    components:
+    - type: Transform
+      pos: 8.5,-7.5
+      parent: 2
+  - uid: 530
+    components:
+    - type: Transform
+      pos: 8.5,-6.5
+      parent: 2
+  - uid: 531
+    components:
+    - type: Transform
+      pos: 8.5,-5.5
+      parent: 2
+  - uid: 532
+    components:
+    - type: Transform
+      pos: 8.5,-4.5
+      parent: 2
+  - uid: 533
+    components:
+    - type: Transform
+      pos: 8.5,-3.5
+      parent: 2
+  - uid: 534
+    components:
+    - type: Transform
+      pos: 7.5,-3.5
+      parent: 2
+  - uid: 535
+    components:
+    - type: Transform
+      pos: 7.5,-2.5
+      parent: 2
+  - uid: 536
+    components:
+    - type: Transform
+      pos: 7.5,-7.5
+      parent: 2
+  - uid: 537
+    components:
+    - type: Transform
+      pos: 6.5,-7.5
+      parent: 2
+  - uid: 538
+    components:
+    - type: Transform
+      pos: 5.5,-7.5
+      parent: 2
+  - uid: 539
+    components:
+    - type: Transform
+      pos: 4.5,-7.5
+      parent: 2
+  - uid: 540
+    components:
+    - type: Transform
+      pos: 3.5,-7.5
+      parent: 2
+  - uid: 541
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 2
+  - uid: 542
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 2
+  - uid: 543
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 2
+  - uid: 544
+    components:
+    - type: Transform
+      pos: -0.5,-7.5
+      parent: 2
+  - uid: 545
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 2
+  - uid: 546
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 2
+  - uid: 547
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 2
+  - uid: 548
+    components:
+    - type: Transform
+      pos: -4.5,-7.5
+      parent: 2
+  - uid: 549
+    components:
+    - type: Transform
+      pos: -5.5,-7.5
+      parent: 2
+  - uid: 550
+    components:
+    - type: Transform
+      pos: -6.5,-7.5
+      parent: 2
+  - uid: 551
+    components:
+    - type: Transform
+      pos: -7.5,-7.5
+      parent: 2
+  - uid: 552
+    components:
+    - type: Transform
+      pos: -8.5,-7.5
+      parent: 2
+  - uid: 553
+    components:
+    - type: Transform
+      pos: -9.5,-7.5
+      parent: 2
+  - uid: 554
+    components:
+    - type: Transform
+      pos: -9.5,-7.5
+      parent: 2
+  - uid: 555
+    components:
+    - type: Transform
+      pos: -9.5,-8.5
+      parent: 2
+  - uid: 556
+    components:
+    - type: Transform
+      pos: -9.5,-9.5
+      parent: 2
+  - uid: 558
+    components:
+    - type: Transform
+      pos: -9.5,-11.5
+      parent: 2
+  - uid: 559
+    components:
+    - type: Transform
+      pos: -9.5,-12.5
+      parent: 2
+  - uid: 560
+    components:
+    - type: Transform
+      pos: -9.5,-13.5
+      parent: 2
+  - uid: 561
+    components:
+    - type: Transform
+      pos: -9.5,-14.5
+      parent: 2
+  - uid: 562
+    components:
+    - type: Transform
+      pos: -10.5,-14.5
+      parent: 2
+  - uid: 563
+    components:
+    - type: Transform
+      pos: -11.5,-14.5
+      parent: 2
+  - uid: 564
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 2
+  - uid: 565
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 2
+  - uid: 566
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 2
+  - uid: 567
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 2
+  - uid: 568
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 2
+  - uid: 569
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 2
+  - uid: 570
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 2
+  - uid: 571
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 2
+  - uid: 572
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 2
+  - uid: 573
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 2
+  - uid: 574
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 2
+  - uid: 575
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 2
+  - uid: 576
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 2
+  - uid: 577
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 2
+  - uid: 578
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 2
+  - uid: 579
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 2
+  - uid: 580
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 2
+  - uid: 581
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 2
+  - uid: 582
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 2
+  - uid: 583
+    components:
+    - type: Transform
+      pos: -5.5,-5.5
+      parent: 2
+  - uid: 584
+    components:
+    - type: Transform
+      pos: -6.5,-5.5
+      parent: 2
+  - uid: 585
+    components:
+    - type: Transform
+      pos: -6.5,-4.5
+      parent: 2
+  - uid: 586
+    components:
+    - type: Transform
+      pos: -6.5,-3.5
+      parent: 2
+  - uid: 587
+    components:
+    - type: Transform
+      pos: -6.5,-2.5
+      parent: 2
+  - uid: 588
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 2
+  - uid: 589
+    components:
+    - type: Transform
+      pos: -7.5,4.5
+      parent: 2
+  - uid: 590
+    components:
+    - type: Transform
+      pos: -7.5,5.5
+      parent: 2
+  - uid: 591
+    components:
+    - type: Transform
+      pos: -7.5,6.5
+      parent: 2
+  - uid: 592
+    components:
+    - type: Transform
+      pos: -7.5,7.5
+      parent: 2
+  - uid: 593
+    components:
+    - type: Transform
+      pos: -7.5,8.5
+      parent: 2
+  - uid: 594
+    components:
+    - type: Transform
+      pos: -7.5,9.5
+      parent: 2
+  - uid: 595
+    components:
+    - type: Transform
+      pos: -6.5,9.5
+      parent: 2
+  - uid: 596
+    components:
+    - type: Transform
+      pos: -5.5,9.5
+      parent: 2
+  - uid: 597
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 2
+  - uid: 598
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 2
+  - uid: 599
+    components:
+    - type: Transform
+      pos: 7.5,6.5
+      parent: 2
+  - uid: 600
+    components:
+    - type: Transform
+      pos: 7.5,7.5
+      parent: 2
+  - uid: 601
+    components:
+    - type: Transform
+      pos: 7.5,8.5
+      parent: 2
+  - uid: 602
+    components:
+    - type: Transform
+      pos: 7.5,9.5
+      parent: 2
+  - uid: 603
+    components:
+    - type: Transform
+      pos: 6.5,9.5
+      parent: 2
+  - uid: 604
+    components:
+    - type: Transform
+      pos: 5.5,9.5
+      parent: 2
+- proto: CableMVStack1
+  entities:
+  - uid: 345
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.657139,-13.679013
+      parent: 2
+  - uid: 678
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.271722,-10.72068
+      parent: 2
+- proto: CableTerminal
+  entities:
+  - uid: 605
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-14.5
+      parent: 2
+  - uid: 606
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-15.5
+      parent: 2
+- proto: CargoPallet
+  entities:
+  - uid: 607
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-12.5
+      parent: 2
+  - uid: 608
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-13.5
+      parent: 2
+  - uid: 609
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-14.5
+      parent: 2
+  - uid: 610
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-12.5
+      parent: 2
+  - uid: 611
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-13.5
+      parent: 2
+  - uid: 612
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-14.5
+      parent: 2
+- proto: Catwalk
+  entities:
+  - uid: 613
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-10.5
+      parent: 2
+  - uid: 614
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-15.5
+      parent: 2
+  - uid: 615
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-14.5
+      parent: 2
+  - uid: 616
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-14.5
+      parent: 2
+  - uid: 617
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-15.5
+      parent: 2
+  - uid: 618
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-16.5
+      parent: 2
+  - uid: 619
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-16.5
+      parent: 2
+  - uid: 620
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-14.5
+      parent: 2
+  - uid: 621
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-15.5
+      parent: 2
+  - uid: 622
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-14.5
+      parent: 2
+  - uid: 623
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-15.5
+      parent: 2
+  - uid: 624
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-16.5
+      parent: 2
+  - uid: 625
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-16.5
+      parent: 2
+  - uid: 626
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-15.5
+      parent: 2
+  - uid: 627
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-14.5
+      parent: 2
+  - uid: 628
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-14.5
+      parent: 2
+  - uid: 629
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-15.5
+      parent: 2
+  - uid: 630
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-16.5
+      parent: 2
+  - uid: 631
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-16.5
+      parent: 2
+  - uid: 632
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-15.5
+      parent: 2
+  - uid: 633
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-14.5
+      parent: 2
+  - uid: 634
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-12.5
+      parent: 2
+  - uid: 635
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-11.5
+      parent: 2
+  - uid: 636
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,0.5
+      parent: 2
+  - uid: 637
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-9.5
+      parent: 2
+  - uid: 638
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-10.5
+      parent: 2
+  - uid: 639
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-11.5
+      parent: 2
+  - uid: 640
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-12.5
+      parent: 2
+  - uid: 641
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-12.5
+      parent: 2
+  - uid: 642
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-11.5
+      parent: 2
+  - uid: 643
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-10.5
+      parent: 2
+  - uid: 644
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,0.5
+      parent: 2
+  - uid: 645
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,0.5
+      parent: 2
+  - uid: 646
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-12.5
+      parent: 2
+  - uid: 647
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-11.5
+      parent: 2
+  - uid: 648
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-12.5
+      parent: 2
+  - uid: 649
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,0.5
+      parent: 2
+  - uid: 650
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,11.5
+      parent: 2
+  - uid: 651
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,11.5
+      parent: 2
+  - uid: 652
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,11.5
+      parent: 2
+  - uid: 653
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,11.5
+      parent: 2
+  - uid: 654
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-16.5
+      parent: 2
+  - uid: 655
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-16.5
+      parent: 2
+  - uid: 656
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-16.5
+      parent: 2
+  - uid: 657
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-16.5
+      parent: 2
+  - uid: 658
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-16.5
+      parent: 2
+- proto: ChairOfficeLight
+  entities:
+  - uid: 1798
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.191841,7.5418878
+      parent: 2
+  - uid: 1799
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.718965,7.1043878
+      parent: 2
+  - uid: 1800
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.718965,5.5887628
+      parent: 2
+- proto: ChairPilotSeat
+  entities:
+  - uid: 660
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,4.5
+      parent: 2
+  - uid: 661
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,0.5
+      parent: 2
+- proto: CircuitImprinter
+  entities:
+  - uid: 1177
+    components:
+    - type: Transform
+      pos: -5.5,8.5
+      parent: 2
+- proto: ClockworkGrille
+  entities:
+  - uid: 663
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,6.5
+      parent: 2
+  - uid: 664
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,6.5
+      parent: 2
+  - uid: 665
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,6.5
+      parent: 2
+  - uid: 666
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-4.5
+      parent: 2
+  - uid: 667
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-3.5
+      parent: 2
+  - uid: 668
+    components:
+    - type: Transform
+      pos: 9.5,-3.5
+      parent: 2
+  - uid: 669
+    components:
+    - type: Transform
+      pos: 9.5,-4.5
+      parent: 2
+- proto: ClosetSteelBase
+  entities:
+  - uid: 670
+    components:
+    - type: Transform
+      pos: -9.5,-4.5
+      parent: 2
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 672
+          - 671
+          - 674
+          - 673
+          - 675
+          - 676
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: ClothingEyesBlindfold
+  entities:
+  - uid: 671
+    components:
+    - type: Transform
+      parent: 670
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 672
+    components:
+    - type: Transform
+      parent: 670
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ClothingMaskMuzzle
+  entities:
+  - uid: 673
+    components:
+    - type: Transform
+      parent: 670
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 674
+    components:
+    - type: Transform
+      parent: 670
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ClothingOuterHardsuitMercenary
+  entities:
+  - uid: 1264
+    components:
+    - type: Transform
+      pos: 8.490873,11.564101
+      parent: 2
+  - uid: 1731
+    components:
+    - type: Transform
+      pos: 9.459623,11.548476
+      parent: 2
+- proto: ClothingUniformJumpskirtPrisoner
+  entities:
+  - uid: 675
+    components:
+    - type: Transform
+      parent: 670
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ClothingUniformJumpskirtSec
+  entities:
+  - uid: 1768
+    components:
+    - type: MetaData
+      desc: То же самое что и боец но без прав.
+      name: комбинезон vitezstvi (боецка)
+    - type: Transform
+      parent: 1763
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ClothingUniformJumpsuitBrigmedic
+  entities:
+  - uid: 1766
+    components:
+    - type: MetaData
+      desc: От этой формы несет профессионализмом в пофигизме и запахом 95% спирта использованного не по назначению.
+      name: комбинезон vitezstvi (военный врач)
+    - type: Transform
+      parent: 1763
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ClothingUniformJumpsuitHoS
+  entities:
+  - uid: 1770
+    components:
+    - type: MetaData
+      desc: От этой формы несет немытыми подмышками и запахом напалма по утрам
+      name: комбинезон vitezstvi (командира отряда)
+    - type: Transform
+      parent: 1763
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ClothingUniformJumpsuitPrisoner
+  entities:
+  - uid: 676
+    components:
+    - type: Transform
+      parent: 670
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ClothingUniformJumpsuitSec
+  entities:
+  - uid: 1765
+    components:
+    - type: MetaData
+      desc: От этой формы несет 100% меткостью в спины товарищей. Враг у ворот!
+      name: комбинезон vitezstvi (боец)
+    - type: Transform
+      parent: 1763
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1767
+    components:
+    - type: MetaData
+      desc: От этой формы несет 100% меткостью в спины товарищей. Враг у ворот!
+      name: комбинезон vitezstvi (боец)
+    - type: Transform
+      parent: 1763
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1769
+    components:
+    - type: MetaData
+      desc: От этой формы несет 100% меткостью в спины товарищей. Враг у ворот!
+      name: комбинезон vitezstvi (боец)
+    - type: Transform
+      parent: 1763
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ClothingUniformJumpsuitSeniorOfficer
+  entities:
+  - uid: 1764
+    components:
+    - type: MetaData
+      desc: От этой формы несет пилотом, не советуем приближаться к ней ближе чем на 200 метров.
+      name: комбинезон vitezstvi (пилот)
+    - type: Transform
+      parent: 1763
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: Cobweb1
+  entities:
+  - uid: 680
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,10.5
+      parent: 2
+  - uid: 681
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,4.5
+      parent: 2
+  - uid: 682
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,6.5
+      parent: 2
+- proto: Cobweb2
+  entities:
+  - uid: 685
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,4.5
+      parent: 2
+  - uid: 686
+    components:
+    - type: Transform
+      pos: 12.5,5.5
+      parent: 2
+  - uid: 687
+    components:
+    - type: Transform
+      pos: 9.5,11.5
+      parent: 2
+- proto: ComputerAnalysisConsole
+  entities:
+  - uid: 1007
+    components:
+    - type: Transform
+      pos: -5.5,12.5
+      parent: 2
+- proto: ComputerBroken
+  entities:
+  - uid: 688
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,4.5
+      parent: 2
+- proto: ComputerRadar
+  entities:
+  - uid: 691
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 2
+  - uid: 1714
+    components:
+    - type: Transform
+      pos: 6.5,12.5
+      parent: 2
+- proto: ComputerResearchAndDevelopment
+  entities:
+  - uid: 684
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,5.5
+      parent: 2
+- proto: ComputerSalvageExpedition
+  entities:
+  - uid: 692
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,3.5
+      parent: 2
+- proto: ComputerShuttle
+  entities:
+  - uid: 693
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 2
+- proto: ComputerStationRecords
+  entities:
+  - uid: 694
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,3.5
+      parent: 2
+- proto: ConveyorBelt
+  entities:
+  - uid: 1788
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,3.5
+      parent: 2
+  - uid: 1789
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,4.5
+      parent: 2
+- proto: CrateAmmoSecureMercenary
+  entities:
+  - uid: 1771
+    components:
+    - type: Transform
+      pos: 11.5,4.5
+      parent: 2
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14923
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 1742
+          - 1736
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+  - uid: 1772
+    components:
+    - type: Transform
+      pos: 12.5,5.5
+      parent: 2
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14923
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 1740
+          - 1238
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+  - uid: 1774
+    components:
+    - type: Transform
+      pos: 12.5,4.5
+      parent: 2
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14923
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 662
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: CrateGenericSteel
+  entities:
+  - uid: 1715
+    components:
+    - type: Transform
+      pos: 10.5,-1.5
+      parent: 2
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14908
+        moles:
+        - 1.606311
+        - 6.042789
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 1716
+          - 1717
+          - 1718
+          - 1719
+          - 1720
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: CrateScienceSecure
+  entities:
+  - uid: 1792
+    components:
+    - type: Transform
+      pos: -9.5,8.5
+      parent: 2
+    - type: Lock
+      locked: False
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14923
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+- proto: CrateWeaponSecure
+  entities:
+  - uid: 1763
+    components:
+    - type: MetaData
+      name: защищённый ящик снаряжения vitezstvi
+    - type: Transform
+      pos: 10.5,2.5
+      parent: 2
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14923
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 1764
+          - 1765
+          - 1766
+          - 1767
+          - 1768
+          - 1769
+          - 1770
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: CrowbarRed
+  entities:
+  - uid: 1651
+    components:
+    - type: Transform
+      pos: -6.4486837,5.52696
+      parent: 2
+- proto: CyberPen
+  entities:
+  - uid: 1795
+    components:
+    - type: Transform
+      pos: -10.314268,7.7216434
+      parent: 2
+- proto: DefibrillatorCabinetFilled
+  entities:
+  - uid: 695
+    components:
+    - type: Transform
+      pos: -3.5,-11.5
+      parent: 2
+  - uid: 696
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-11.5
+      parent: 2
+- proto: DrinkBeerBottleFull
+  entities:
+  - uid: 976
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -11.348493,4.7669077
+      parent: 2
+  - uid: 1718
+    components:
+    - type: Transform
+      parent: 1715
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1719
+    components:
+    - type: Transform
+      parent: 1715
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1720
+    components:
+    - type: Transform
+      parent: 1715
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: DrinkBeerglass
+  entities:
+  - uid: 1716
+    components:
+    - type: Transform
+      parent: 1715
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1717
+    components:
+    - type: Transform
+      parent: 1715
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: DrinkKegWood
+  entities:
+  - uid: 701
+    components:
+    - type: Transform
+      pos: 11.548131,2.545815
+      parent: 2
+    - type: ItemSlots
+    - type: ContainerContainer
+      containers:
+        paper_label: !type:ContainerSlot {}
+- proto: DrinkVodkaBottleFull
+  entities:
+  - uid: 975
+    components:
+    - type: Transform
+      pos: 1.1986111,0.54011405
+      parent: 2
+  - uid: 979
+    components:
+    - type: Transform
+      pos: -0.49726582,4.898858
+      parent: 2
+- proto: EggSpider
+  entities:
+  - uid: 1171
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.485755,-16.436047
+      parent: 2
+  - uid: 1176
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.569089,-12.488131
+      parent: 2
+- proto: EmergencyLight
+  entities:
+  - uid: 702
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,0.5
+      parent: 2
+  - uid: 703
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,9.5
+      parent: 2
+  - uid: 704
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,0.5
+      parent: 2
+  - uid: 705
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,9.5
+      parent: 2
+  - uid: 706
+    components:
+    - type: Transform
+      pos: -5.5,12.5
+      parent: 2
+  - uid: 707
+    components:
+    - type: Transform
+      pos: 6.5,12.5
+      parent: 2
+  - uid: 708
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-16.5
+      parent: 2
+  - uid: 709
+    components:
+    - type: Transform
+      pos: 5.5,-11.5
+      parent: 2
+  - uid: 710
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,2.5
+      parent: 2
+  - uid: 711
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-10.5
+      parent: 2
+  - uid: 712
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-10.5
+      parent: 2
+  - uid: 713
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-9.5
+      parent: 2
+  - uid: 714
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-13.5
+      parent: 2
+  - uid: 715
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-9.5
+      parent: 2
+  - uid: 716
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-13.5
+      parent: 2
+  - uid: 717
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-14.5
+      parent: 2
+  - uid: 718
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-14.5
+      parent: 2
+  - uid: 719
+    components:
+    - type: Transform
+      pos: -6.5,-3.5
+      parent: 2
+  - uid: 720
+    components:
+    - type: Transform
+      pos: 7.5,-3.5
+      parent: 2
+  - uid: 721
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-7.5
+      parent: 2
+  - uid: 722
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-7.5
+      parent: 2
+  - uid: 723
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-8.5
+      parent: 2
+  - uid: 724
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-8.5
+      parent: 2
+- proto: FaxMachineShip
+  entities:
+  - uid: 980
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 2
+- proto: FireAxeCabinetOpen
+  entities:
+  - uid: 725
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-1.5
+      parent: 2
+- proto: Firelock
+  entities:
+  - uid: 726
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,0.5
+      parent: 2
+  - uid: 727
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-2.5
+      parent: 2
+  - uid: 728
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,-0.5
+      parent: 2
+  - uid: 729
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,1.5
+      parent: 2
+  - uid: 730
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,3.5
+      parent: 2
+  - uid: 731
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,0.5
+      parent: 2
+  - uid: 732
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-11.5
+      parent: 2
+  - uid: 733
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-11.5
+      parent: 2
+  - uid: 734
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-11.5
+      parent: 2
+  - uid: 735
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,3.5
+      parent: 2
+  - uid: 736
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-8.5
+      parent: 2
+  - uid: 737
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-8.5
+      parent: 2
+  - uid: 738
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-5.5
+      parent: 2
+  - uid: 739
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-2.5
+      parent: 2
+  - uid: 740
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,1.5
+      parent: 2
+  - uid: 741
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-0.5
+      parent: 2
+- proto: FirelockEdge
+  entities:
+  - uid: 742
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 2
+  - uid: 743
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 2
+  - uid: 744
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 2
+  - uid: 745
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-5.5
+      parent: 2
+  - uid: 746
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-6.5
+      parent: 2
+  - uid: 747
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-7.5
+      parent: 2
+  - uid: 748
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-8.5
+      parent: 2
+    - type: Door
+      secondsUntilStateChange: -13264.797
+      state: Closing
+  - uid: 749
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-9.5
+      parent: 2
+  - uid: 750
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-5.5
+      parent: 2
+  - uid: 751
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-6.5
+      parent: 2
+    - type: Door
+      secondsUntilStateChange: -14766.806
+      state: Closing
+  - uid: 752
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-7.5
+      parent: 2
+  - uid: 753
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-8.5
+      parent: 2
+  - uid: 754
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-9.5
+      parent: 2
+  - uid: 756
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-2.5
+      parent: 2
+  - uid: 757
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-2.5
+      parent: 2
+  - uid: 758
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-2.5
+      parent: 2
+- proto: FloorDrain
+  entities:
+  - uid: 759
+    components:
+    - type: Transform
+      pos: -8.5,-14.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+- proto: FoodBowlBig
+  entities:
+  - uid: 1722
+    components:
+    - type: Transform
+      pos: 1.4888316,-7.4656334
+      parent: 2
+  - uid: 1737
+    components:
+    - type: Transform
+      pos: -0.2554294,-8.372853
+      parent: 2
+  - uid: 1754
+    components:
+    - type: Transform
+      pos: 0.09994292,-6.3718834
+      parent: 2
+- proto: FoodMeatSpider
+  entities:
+  - uid: 1166
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.9617243,-13.734124
+      parent: 2
+  - uid: 1652
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.4825573,-14.411207
+      parent: 2
+  - uid: 1653
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.9304743,-12.71329
+      parent: 2
+- proto: GasPassiveVent
+  entities:
+  - uid: 760
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 761
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1685
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,10.5
+      parent: 2
+  - uid: 1686
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,12.5
+      parent: 2
+- proto: GasPipeBend
+  entities:
+  - uid: 762
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 763
+    components:
+    - type: Transform
+      pos: 2.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 764
+    components:
+    - type: Transform
+      pos: 8.5,6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 765
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 766
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 767
+    components:
+    - type: Transform
+      pos: -8.5,8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 768
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 769
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 770
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 771
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-13.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 772
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 773
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-13.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 774
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 775
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 776
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 777
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1692
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,10.5
+      parent: 2
+  - uid: 1693
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,9.5
+      parent: 2
+  - uid: 1695
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,12.5
+      parent: 2
+  - uid: 1707
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,10.5
+      parent: 2
+- proto: GasPipeFourway
+  entities:
+  - uid: 778
+    components:
+    - type: Transform
+      pos: 1.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 779
+    components:
+    - type: Transform
+      pos: -7.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 780
+    components:
+    - type: Transform
+      pos: 9.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 781
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+- proto: GasPipeStraight
+  entities:
+  - uid: 782
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 783
+    components:
+    - type: Transform
+      pos: -1.5,-15.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 784
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 785
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 786
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-15.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 787
+    components:
+    - type: Transform
+      pos: -8.5,7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 788
+    components:
+    - type: Transform
+      pos: -8.5,6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 789
+    components:
+    - type: Transform
+      pos: -8.5,5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 790
+    components:
+    - type: Transform
+      pos: -8.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 791
+    components:
+    - type: Transform
+      pos: -8.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 792
+    components:
+    - type: Transform
+      pos: -8.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 793
+    components:
+    - type: Transform
+      pos: -8.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 794
+    components:
+    - type: Transform
+      pos: -7.5,5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 795
+    components:
+    - type: Transform
+      pos: -7.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 796
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 797
+    components:
+    - type: Transform
+      pos: -7.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 798
+    components:
+    - type: Transform
+      pos: -7.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 799
+    components:
+    - type: Transform
+      pos: -7.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 800
+    components:
+    - type: Transform
+      pos: -8.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 801
+    components:
+    - type: Transform
+      pos: -8.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 802
+    components:
+    - type: Transform
+      pos: -8.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 803
+    components:
+    - type: Transform
+      pos: -8.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 804
+    components:
+    - type: Transform
+      pos: -8.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 805
+    components:
+    - type: Transform
+      pos: -8.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 806
+    components:
+    - type: Transform
+      pos: -8.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 807
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-11.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 808
+    components:
+    - type: Transform
+      pos: -7.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 809
+    components:
+    - type: Transform
+      pos: -7.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 810
+    components:
+    - type: Transform
+      pos: -7.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 811
+    components:
+    - type: Transform
+      pos: -7.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 812
+    components:
+    - type: Transform
+      pos: -7.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 813
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 814
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 815
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 816
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 817
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 818
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 819
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 820
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 821
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 822
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 823
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 824
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 825
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 826
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 827
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 828
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 829
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 830
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 831
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 832
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 833
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 834
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 835
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 836
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 837
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 838
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 839
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 840
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 841
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 842
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 843
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 844
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 845
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 846
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 847
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 848
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 849
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 850
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 851
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 852
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 853
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 854
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 855
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 856
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 857
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 858
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 859
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 860
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 861
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 862
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 863
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 864
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 865
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 866
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 867
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 868
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 869
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 870
+    components:
+    - type: Transform
+      pos: 10.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 871
+    components:
+    - type: Transform
+      pos: 10.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 872
+    components:
+    - type: Transform
+      pos: 11.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 873
+    components:
+    - type: Transform
+      pos: 11.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 874
+    components:
+    - type: Transform
+      pos: 11.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 875
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 876
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 877
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 878
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 879
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 880
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-13.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 881
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-13.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 882
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 883
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 884
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 885
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 886
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-11.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 887
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 888
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 889
+    components:
+    - type: Transform
+      pos: -0.5,-10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 890
+    components:
+    - type: Transform
+      pos: -0.5,-11.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 891
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 892
+    components:
+    - type: Transform
+      pos: 1.5,-8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 893
+    components:
+    - type: Transform
+      pos: 1.5,-9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 894
+    components:
+    - type: Transform
+      pos: 1.5,-10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 895
+    components:
+    - type: Transform
+      pos: 1.5,-11.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 896
+    components:
+    - type: Transform
+      pos: 1.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 897
+    components:
+    - type: Transform
+      pos: -7.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 898
+    components:
+    - type: Transform
+      pos: -7.5,-8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 899
+    components:
+    - type: Transform
+      pos: -7.5,-9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 900
+    components:
+    - type: Transform
+      pos: -7.5,-10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 901
+    components:
+    - type: Transform
+      pos: -7.5,-11.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 902
+    components:
+    - type: Transform
+      pos: -9.5,-13.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 903
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 904
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 905
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 906
+    components:
+    - type: Transform
+      pos: -6.5,-13.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 907
+    components:
+    - type: Transform
+      pos: -6.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 908
+    components:
+    - type: Transform
+      pos: -6.5,-11.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 909
+    components:
+    - type: Transform
+      pos: -6.5,-10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 910
+    components:
+    - type: Transform
+      pos: -6.5,-9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 911
+    components:
+    - type: Transform
+      pos: -6.5,-8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 912
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 913
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 914
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 915
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 916
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 917
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 918
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 919
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 920
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 921
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 922
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 923
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 1688
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,10.5
+      parent: 2
+  - uid: 1690
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,9.5
+      parent: 2
+  - uid: 1691
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,9.5
+      parent: 2
+  - uid: 1694
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,11.5
+      parent: 2
+  - uid: 1696
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,10.5
+      parent: 2
+  - uid: 1697
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,10.5
+      parent: 2
+  - uid: 1698
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,10.5
+      parent: 2
+  - uid: 1699
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,10.5
+      parent: 2
+  - uid: 1700
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,10.5
+      parent: 2
+  - uid: 1701
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,12.5
+      parent: 2
+  - uid: 1702
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,12.5
+      parent: 2
+  - uid: 1703
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,12.5
+      parent: 2
+  - uid: 1704
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,12.5
+      parent: 2
+  - uid: 1705
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,12.5
+      parent: 2
+  - uid: 1706
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,12.5
+      parent: 2
+- proto: GasPipeTJunction
+  entities:
+  - uid: 924
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 925
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 926
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 927
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 928
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 929
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 930
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 931
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 932
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 933
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 934
+    components:
+    - type: Transform
+      pos: -5.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 935
+    components:
+    - type: Transform
+      pos: 6.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 936
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 937
+    components:
+    - type: Transform
+      pos: -6.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 938
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 939
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 940
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 941
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 942
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+- proto: GasPort
+  entities:
+  - uid: 943
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-13.5
+      parent: 2
+  - uid: 997
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,10.5
+      parent: 2
+  - uid: 998
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,9.5
+      parent: 2
+- proto: GasPressurePump
+  entities:
+  - uid: 944
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-13.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 1687
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,10.5
+      parent: 2
+  - uid: 1689
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,9.5
+      parent: 2
+- proto: GasValve
+  entities:
+  - uid: 945
+    components:
+    - type: Transform
+      pos: -0.5,-13.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+- proto: GasVentPump
+  entities:
+  - uid: 946
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-13.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 947
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-12.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 6
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 948
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 949
+    components:
+    - type: Transform
+      pos: -11.5,-3.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 6
+      - 7
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 950
+    components:
+    - type: Transform
+      pos: 10.5,-3.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 5
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 951
+    components:
+    - type: Transform
+      pos: -6.5,-5.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 7
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 952
+    components:
+    - type: Transform
+      pos: 7.5,-5.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 5
+      - 7
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 953
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+      - 7
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 954
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+      - 7
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 955
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-0.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 9
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 956
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-0.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 10
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 957
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,6.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 8
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 958
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,6.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 11
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+  - uid: 959
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-13.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 5
+    - type: AtmosPipeColor
+      color: '#0000FFFF'
+- proto: GasVentScrubber
+  entities:
+  - uid: 960
+    components:
+    - type: Transform
+      pos: -9.5,-3.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 6
+      - 7
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 961
+    components:
+    - type: Transform
+      pos: 11.5,-3.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 5
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 962
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-8.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 7
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 963
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-8.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 5
+      - 7
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 964
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-10.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+      - 7
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 965
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+      - 7
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 966
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,8.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 8
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 967
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,8.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 11
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 968
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,0.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 9
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 969
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,0.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 10
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 970
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-13.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 5
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 971
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-12.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 972
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 973
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-14.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 6
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 974
+    components:
+    - type: Transform
+      pos: 7.5,-16.5
+      parent: 2
+- proto: GrilleBroken
+  entities:
+  - uid: 1675
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 2
+  - uid: 1677
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,9.5
+      parent: 2
+  - uid: 1678
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,9.5
+      parent: 2
+  - uid: 1679
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,9.5
+      parent: 2
+  - uid: 1680
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,13.5
+      parent: 2
+  - uid: 1681
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,13.5
+      parent: 2
+  - uid: 1682
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,13.5
+      parent: 2
+  - uid: 1683
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,13.5
+      parent: 2
+  - uid: 1684
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,9.5
+      parent: 2
+- proto: GunSafe
+  entities:
+  - uid: 987
+    components:
+    - type: Transform
+      pos: 10.5,10.5
+      parent: 2
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14914
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 989
+          - 988
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+  - uid: 1745
+    components:
+    - type: Transform
+      pos: 6.5,6.5
+      parent: 2
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14908
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 1543
+          - 1187
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: Gyroscope
+  entities:
+  - uid: 689
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 2
+  - uid: 977
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 2
+  - uid: 978
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 2
+  - uid: 1777
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 2
+- proto: HandHeldMassScanner
+  entities:
+  - uid: 1070
+    components:
+    - type: Transform
+      parent: 1069
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1134
+    components:
+    - type: Transform
+      parent: 1131
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: KitchenMicrowave
+  entities:
+  - uid: 1629
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 2
+- proto: KukriKnife
+  entities:
+  - uid: 193
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5540402,-0.0855999
+      parent: 192
+    - type: Physics
+      canCollide: False
+      bodyType: Static
+  - uid: 981
+    components:
+    - type: Transform
+      pos: 11.498602,7.6255636
+      parent: 2
+- proto: LockerEngineerFilledHardsuit
+  entities:
+  - uid: 984
+    components:
+    - type: Transform
+      pos: 5.5,-11.5
+      parent: 2
+- proto: LockerMercenary
+  entities:
+  - uid: 1069
+    components:
+    - type: Transform
+      pos: 6.5,8.5
+      parent: 2
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14923
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 1121
+          - 1070
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+  - uid: 1131
+    components:
+    - type: Transform
+      pos: 6.5,7.5
+      parent: 2
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14923
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 1148
+          - 1134
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: LockerParamedicFilledHardsuit
+  entities:
+  - uid: 198
+    components:
+    - type: Transform
+      pos: -7.5,-16.5
+      parent: 2
+- proto: LockerSalvageSpecialistFilledHardsuit
+  entities:
+  - uid: 1638
+    components:
+    - type: Transform
+      pos: 2.5,-12.5
+      parent: 2
+- proto: MachineAPE
+  entities:
+  - uid: 1801
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,11.5
+      parent: 2
+- proto: MachineArtifactAnalyzer
+  entities:
+  - uid: 1252
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 2
+- proto: MachineFlatpacker
+  entities:
+  - uid: 1785
+    components:
+    - type: Transform
+      pos: -8.5,8.5
+      parent: 2
+- proto: MachineFrameDestroyed
+  entities:
+  - uid: 1000
+    components:
+    - type: Transform
+      pos: 6.5,-10.5
+      parent: 2
+- proto: Mattress
+  entities:
+  - uid: 1001
+    components:
+    - type: Transform
+      pos: -9.5,-3.5
+      parent: 2
+  - uid: 1002
+    components:
+    - type: Transform
+      pos: -11.5,-3.5
+      parent: 2
+- proto: MedicalBed
+  entities:
+  - uid: 1004
+    components:
+    - type: Transform
+      pos: -5.5,-10.5
+      parent: 2
+  - uid: 1157
+    components:
+    - type: Transform
+      pos: -4.5,-16.5
+      parent: 2
+  - uid: 1162
+    components:
+    - type: Transform
+      pos: -6.5,-16.5
+      parent: 2
+  - uid: 1728
+    components:
+    - type: Transform
+      pos: -7.5,-10.5
+      parent: 2
+- proto: MedkitFilled
+  entities:
+  - uid: 679
+    components:
+    - type: Transform
+      pos: -6.453952,-10.427102
+      parent: 2
+- proto: NodeScanner
+  entities:
+  - uid: 1010
+    components:
+    - type: Transform
+      pos: -8.32859,11.754007
+      parent: 2
+- proto: OreProcessor
+  entities:
+  - uid: 1778
+    components:
+    - type: Transform
+      pos: -6.5,3.5
+      parent: 2
+- proto: OxygenTankFilled
+  entities:
+  - uid: 1733
+    components:
+    - type: Transform
+      pos: 9.450583,11.618082
+      parent: 2
+  - uid: 1738
+    components:
+    - type: Transform
+      pos: 8.528708,11.571207
+      parent: 2
+- proto: PenCentcom
+  entities:
+  - uid: 1794
+    components:
+    - type: Transform
+      pos: -10.642393,7.7060184
+      parent: 2
+- proto: PinpointerUniversal
+  entities:
+  - uid: 1121
+    components:
+    - type: Transform
+      parent: 1069
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1148
+    components:
+    - type: Transform
+      parent: 1131
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1265
+    components:
+    - type: Transform
+      pos: 8.546928,11.567528
+      parent: 2
+  - uid: 1730
+    components:
+    - type: Transform
+      pos: 9.497397,11.580221
+      parent: 2
+- proto: PlastitaniumWindow
+  entities:
+  - uid: 1014
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 2
+  - uid: 1015
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 2
+  - uid: 1016
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 2
+  - uid: 1017
+    components:
+    - type: Transform
+      pos: 9.5,-3.5
+      parent: 2
+  - uid: 1160
+    components:
+    - type: Transform
+      pos: -8.5,-4.5
+      parent: 2
+  - uid: 1266
+    components:
+    - type: Transform
+      pos: 9.5,-4.5
+      parent: 2
+  - uid: 1646
+    components:
+    - type: Transform
+      pos: -8.5,-3.5
+      parent: 2
+  - uid: 1660
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 2
+  - uid: 1661
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 2
+  - uid: 1662
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 2
+  - uid: 1667
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 2
+  - uid: 1668
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 2
+  - uid: 1669
+    components:
+    - type: Transform
+      pos: -0.5,13.5
+      parent: 2
+- proto: PlushieDeer
+  entities:
+  - uid: 1247
+    components:
+    - type: MetaData
+      desc: Очаровательная мягкая игрушка, напоминающая оленя!                                                                                                               Оно имеет сикей "dimonsupe".
+    - type: Transform
+      pos: -1.5197711,-8.480786
+      parent: 2
+- proto: PlushieLoveable
+  entities:
+  - uid: 1723
+    components:
+    - type: MetaData
+      desc: Очаровательная мягкая игрушка, напоминающая... существо.                                                                                                                  Оно имеет сикей "mersen".
+    - type: Transform
+      pos: 2.5264137,-7.4912033
+      parent: 2
+- proto: PlushieOrangeFox
+  entities:
+  - uid: 1242
+    components:
+    - type: MetaData
+      desc: Очаровательная мягкая игрушка, напоминающая лису!                                                                                                       Оно имеет сикей "Terka".
+    - type: Transform
+      pos: 1.5194693,-5.4946756
+      parent: 2
+- proto: PosterBroken
+  entities:
+  - uid: 1019
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,2.5
+      parent: 2
+- proto: PosterContrabandBustyBackdoorExoBabes6
+  entities:
+  - uid: 1020
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,12.5
+      parent: 2
+  - uid: 1021
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,3.5
+      parent: 2
+- proto: PosterContrabandEnlistGorlex
+  entities:
+  - uid: 1022
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-17.5
+      parent: 2
+- proto: PosterContrabandLustyExomorph
+  entities:
+  - uid: 1023
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-2.5
+      parent: 2
+- proto: PosterLegitShoukou
+  entities:
+  - uid: 1024
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-4.5
+      parent: 2
+- proto: PowerCellRecharger
+  entities:
+  - uid: 1729
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 2
+- proto: Poweredlight
+  entities:
+  - uid: 1026
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-13.5
+      parent: 2
+  - uid: 1027
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-13.5
+      parent: 2
+  - uid: 1028
+    components:
+    - type: Transform
+      pos: -10.5,-3.5
+      parent: 2
+  - uid: 1029
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,1.5
+      parent: 2
+  - uid: 1030
+    components:
+    - type: Transform
+      pos: -12.5,-0.5
+      parent: 2
+  - uid: 1031
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-1.5
+      parent: 2
+  - uid: 1032
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-1.5
+      parent: 2
+  - uid: 1033
+    components:
+    - type: Transform
+      pos: 13.5,-0.5
+      parent: 2
+  - uid: 1034
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,1.5
+      parent: 2
+  - uid: 1035
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,3.5
+      parent: 2
+  - uid: 1036
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,3.5
+      parent: 2
+  - uid: 1037
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-1.5
+      parent: 2
+  - uid: 1038
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-1.5
+      parent: 2
+- proto: PoweredlightLED
+  entities:
+  - uid: 1039
+    components:
+    - type: Transform
+      pos: -1.5,-16.5
+      parent: 2
+  - uid: 1040
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,-1.5
+      parent: 2
+  - uid: 1041
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-14.5
+      parent: 2
+  - uid: 1042
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-10.5
+      parent: 2
+  - uid: 1043
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-15.5
+      parent: 2
+  - uid: 1044
+    components:
+    - type: Transform
+      pos: -5.5,-10.5
+      parent: 2
+  - uid: 1045
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-12.5
+      parent: 2
+  - uid: 1046
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-13.5
+      parent: 2
+  - uid: 1047
+    components:
+    - type: Transform
+      pos: 6.5,-10.5
+      parent: 2
+  - uid: 1048
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-16.5
+      parent: 2
+  - uid: 1049
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 2
+  - uid: 1051
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-10.5
+      parent: 2
+  - uid: 1052
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-10.5
+      parent: 2
+  - uid: 1053
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-7.5
+      parent: 2
+  - uid: 1054
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-7.5
+      parent: 2
+  - uid: 1055
+    components:
+    - type: Transform
+      pos: 2.5,-16.5
+      parent: 2
+  - uid: 1056
+    components:
+    - type: Transform
+      pos: -8.5,2.5
+      parent: 2
+  - uid: 1057
+    components:
+    - type: Transform
+      pos: 9.5,2.5
+      parent: 2
+  - uid: 1058
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-1.5
+      parent: 2
+  - uid: 1059
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,7.5
+      parent: 2
+  - uid: 1060
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,6.5
+      parent: 2
+  - uid: 1061
+    components:
+    - type: Transform
+      pos: -7.5,11.5
+      parent: 2
+  - uid: 1062
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,8.5
+      parent: 2
+  - uid: 1063
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,8.5
+      parent: 2
+  - uid: 1064
+    components:
+    - type: Transform
+      pos: 8.5,11.5
+      parent: 2
+  - uid: 1065
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,6.5
+      parent: 2
+  - uid: 1066
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,10.5
+      parent: 2
+  - uid: 1067
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,10.5
+      parent: 2
+  - uid: 1756
+    components:
+    - type: Transform
+      pos: 4.5,-5.5
+      parent: 2
+- proto: PoweredlightPink
+  entities:
+  - uid: 1068
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-4.5
+      parent: 2
+- proto: Protolathe
+  entities:
+  - uid: 1250
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 2
+- proto: Rack
+  entities:
+  - uid: 1071
+    components:
+    - type: Transform
+      pos: -9.5,0.5
+      parent: 2
+  - uid: 1072
+    components:
+    - type: Transform
+      pos: -10.5,0.5
+      parent: 2
+  - uid: 1073
+    components:
+    - type: Transform
+      pos: -8.5,11.5
+      parent: 2
+  - uid: 1074
+    components:
+    - type: Transform
+      pos: -7.5,11.5
+      parent: 2
+  - uid: 1075
+    components:
+    - type: Transform
+      pos: 7.5,-12.5
+      parent: 2
+  - uid: 1076
+    components:
+    - type: Transform
+      pos: 8.5,-12.5
+      parent: 2
+  - uid: 1077
+    components:
+    - type: Transform
+      pos: 9.5,-12.5
+      parent: 2
+  - uid: 1645
+    components:
+    - type: Transform
+      pos: 10.5,0.5
+      parent: 2
+  - uid: 1647
+    components:
+    - type: Transform
+      pos: 11.5,0.5
+      parent: 2
+  - uid: 1724
+    components:
+    - type: Transform
+      pos: 9.5,11.5
+      parent: 2
+  - uid: 1725
+    components:
+    - type: Transform
+      pos: 8.5,11.5
+      parent: 2
+  - uid: 1726
+    components:
+    - type: Transform
+      pos: 10.5,4.5
+      parent: 2
+  - uid: 1727
+    components:
+    - type: Transform
+      pos: 9.5,4.5
+      parent: 2
+- proto: RadioHandheldNF
+  entities:
+  - uid: 1631
+    components:
+    - type: Transform
+      pos: 9.433987,11.488253
+      parent: 2
+  - uid: 1641
+    components:
+    - type: Transform
+      pos: 8.635376,11.522975
+      parent: 2
+- proto: Railing
+  entities:
+  - uid: 1078
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-3.5
+      parent: 2
+  - uid: 1079
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-3.5
+      parent: 2
+  - uid: 1761
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-10.5
+      parent: 2
+  - uid: 1776
+    components:
+    - type: Transform
+      pos: -9.5,4.5
+      parent: 2
+  - uid: 1804
+    components:
+    - type: Transform
+      pos: -8.5,4.5
+      parent: 2
+  - uid: 1805
+    components:
+    - type: Transform
+      pos: -10.5,4.5
+      parent: 2
+  - uid: 1806
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,8.5
+      parent: 2
+  - uid: 1807
+    components:
+    - type: Transform
+      pos: -6.5,6.5
+      parent: 2
+- proto: RailingCorner
+  entities:
+  - uid: 408
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,12.5
+      parent: 2
+  - uid: 557
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,12.5
+      parent: 2
+  - uid: 659
+    components:
+    - type: Transform
+      pos: -6.5,12.5
+      parent: 2
+  - uid: 677
+    components:
+    - type: Transform
+      pos: 5.5,12.5
+      parent: 2
+  - uid: 1180
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,10.5
+      parent: 2
+  - uid: 1181
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,8.5
+      parent: 2
+  - uid: 1237
+    components:
+    - type: Transform
+      pos: -10.5,8.5
+      parent: 2
+  - uid: 1762
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,10.5
+      parent: 2
+- proto: RandomInstruments
+  entities:
+  - uid: 1779
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 2
+- proto: RandomPosterAny
+  entities:
+  - uid: 1080
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-9.5
+      parent: 2
+  - uid: 1081
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-13.5
+      parent: 2
+  - uid: 1082
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-10.5
+      parent: 2
+  - uid: 1083
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-4.5
+      parent: 2
+  - uid: 1084
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,2.5
+      parent: 2
+  - uid: 1085
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,3.5
+      parent: 2
+  - uid: 1086
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,7.5
+      parent: 2
+  - uid: 1087
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,12.5
+      parent: 2
+  - uid: 1088
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,7.5
+      parent: 2
+  - uid: 1089
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-12.5
+      parent: 2
+  - uid: 1090
+    components:
+    - type: Transform
+      pos: -11.5,-6.5
+      parent: 2
+- proto: RandomPosterContrabandDeadDrop
+  entities:
+  - uid: 1780
+    components:
+    - type: Transform
+      pos: -3.5,-17.5
+      parent: 2
+- proto: RandomSpawner
+  entities:
+  - uid: 1091
+    components:
+    - type: Transform
+      pos: -5.5,-13.5
+      parent: 2
+  - uid: 1092
+    components:
+    - type: Transform
+      pos: -10.5,-6.5
+      parent: 2
+  - uid: 1093
+    components:
+    - type: Transform
+      pos: -9.5,-15.5
+      parent: 2
+  - uid: 1094
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 2
+  - uid: 1095
+    components:
+    - type: Transform
+      pos: -5.5,-4.5
+      parent: 2
+  - uid: 1096
+    components:
+    - type: Transform
+      pos: -9.5,-1.5
+      parent: 2
+  - uid: 1097
+    components:
+    - type: Transform
+      pos: -7.5,0.5
+      parent: 2
+  - uid: 1098
+    components:
+    - type: Transform
+      pos: -9.5,2.5
+      parent: 2
+  - uid: 1099
+    components:
+    - type: Transform
+      pos: -7.5,5.5
+      parent: 2
+  - uid: 1100
+    components:
+    - type: Transform
+      pos: -9.5,7.5
+      parent: 2
+  - uid: 1101
+    components:
+    - type: Transform
+      pos: -6.5,8.5
+      parent: 2
+  - uid: 1102
+    components:
+    - type: Transform
+      pos: 6.5,9.5
+      parent: 2
+  - uid: 1103
+    components:
+    - type: Transform
+      pos: 9.5,10.5
+      parent: 2
+  - uid: 1104
+    components:
+    - type: Transform
+      pos: 10.5,8.5
+      parent: 2
+  - uid: 1105
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 2
+  - uid: 1106
+    components:
+    - type: Transform
+      pos: 10.5,-0.5
+      parent: 2
+  - uid: 1107
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 2
+  - uid: 1108
+    components:
+    - type: Transform
+      pos: 8.5,-5.5
+      parent: 2
+  - uid: 1109
+    components:
+    - type: Transform
+      pos: 6.5,-8.5
+      parent: 2
+  - uid: 1110
+    components:
+    - type: Transform
+      pos: 3.5,-6.5
+      parent: 2
+  - uid: 1111
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 2
+  - uid: 1112
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 2
+  - uid: 1113
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 2
+  - uid: 1114
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 2
+  - uid: 1115
+    components:
+    - type: Transform
+      pos: -0.5,-14.5
+      parent: 2
+  - uid: 1116
+    components:
+    - type: Transform
+      pos: -1.5,-14.5
+      parent: 2
+  - uid: 1117
+    components:
+    - type: Transform
+      pos: -1.5,-13.5
+      parent: 2
+  - uid: 1118
+    components:
+    - type: Transform
+      pos: 6.5,-15.5
+      parent: 2
+  - uid: 1119
+    components:
+    - type: Transform
+      pos: 10.5,-13.5
+      parent: 2
+  - uid: 1120
+    components:
+    - type: Transform
+      pos: 6.5,-11.5
+      parent: 2
+- proto: RandomStalagmiteOrCrystal
+  entities:
+  - uid: 1172
+    components:
+    - type: Transform
+      pos: 4.5,15.5
+      parent: 2
+  - uid: 1173
+    components:
+    - type: Transform
+      pos: 3.5,16.5
+      parent: 2
+  - uid: 1240
+    components:
+    - type: Transform
+      pos: 3.5,13.5
+      parent: 2
+- proto: ResearchAndDevelopmentServer
+  entities:
+  - uid: 683
+    components:
+    - type: Transform
+      pos: -11.5,4.5
+      parent: 2
+- proto: SalvagePartsSpawnerLow
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      pos: -6.5,5.5
+      parent: 2
+  - uid: 1151
+    components:
+    - type: Transform
+      pos: -9.5,8.5
+      parent: 2
+  - uid: 1773
+    components:
+    - type: Transform
+      pos: -6.5,11.5
+      parent: 2
+- proto: SalvagePartsSpawnerMid
+  entities:
+  - uid: 1005
+    components:
+    - type: Transform
+      pos: -7.5,10.5
+      parent: 2
+  - uid: 1150
+    components:
+    - type: Transform
+      pos: -10.5,6.5
+      parent: 2
+  - uid: 1159
+    components:
+    - type: Transform
+      pos: -8.5,8.5
+      parent: 2
+- proto: SecBreachingHammer
+  entities:
+  - uid: 1796
+    components:
+    - type: Transform
+      pos: -7.533018,11.440393
+      parent: 2
+- proto: SheetPlasteel10
+  entities:
+  - uid: 1123
+    components:
+    - type: Transform
+      pos: 9.280281,-12.362426
+      parent: 2
+  - uid: 1124
+    components:
+    - type: Transform
+      pos: 9.530281,-12.409333
+      parent: 2
+  - uid: 1125
+    components:
+    - type: Transform
+      pos: 9.655281,-12.409333
+      parent: 2
+- proto: SheetSteel10
+  entities:
+  - uid: 1126
+    components:
+    - type: Transform
+      pos: 8.249031,-12.362426
+      parent: 2
+  - uid: 1127
+    components:
+    - type: Transform
+      pos: 8.436531,-12.37806
+      parent: 2
+  - uid: 1128
+    components:
+    - type: Transform
+      pos: 8.608406,-12.37806
+      parent: 2
+- proto: SignalButton
+  entities:
+  - uid: 982
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 2
+  - uid: 983
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 2
+  - uid: 1129
+    components:
+    - type: Transform
+      pos: -9.5,-5.5
+      parent: 2
+  - uid: 1130
+    components:
+    - type: MetaData
+      name: Затвор
+    - type: Transform
+      pos: -5.5,12.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        199:
+        - Pressed: Toggle
+  - uid: 1132
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,0.5
+      parent: 2
+    - type: SignalSwitch
+      state: True
+    - type: DeviceLinkSource
+      linkedPorts:
+        205:
+        - Pressed: Toggle
+        204:
+        - Pressed: Toggle
+  - uid: 1133
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,0.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        206:
+        - Pressed: Toggle
+        207:
+        - Pressed: Toggle
+  - uid: 1309
+    components:
+    - type: Transform
+      pos: 6.5,12.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        203:
+        - Pressed: Toggle
+  - uid: 1672
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,12.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        1673:
+        - Pressed: Toggle
+        1674:
+        - Pressed: Toggle
+  - uid: 1676
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,12.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        1674:
+        - Pressed: Toggle
+        1673:
+        - Pressed: Toggle
+- proto: SignalSwitch
+  entities:
+  - uid: 1791
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,5.5
+      parent: 2
+- proto: SignBridge
+  entities:
+  - uid: 1135
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-3.5
+      parent: 2
+  - uid: 1136
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-3.5
+      parent: 2
+- proto: SignCargoDock
+  entities:
+  - uid: 1137
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-11.5
+      parent: 2
+- proto: SignEngineering
+  entities:
+  - uid: 1138
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-8.5
+      parent: 2
+- proto: SignMedical
+  entities:
+  - uid: 1139
+    components:
+    - type: Transform
+      pos: -8.5,-8.5
+      parent: 2
+- proto: SignMinerDock
+  entities:
+  - uid: 1140
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-11.5
+      parent: 2
+- proto: SignRND
+  entities:
+  - uid: 1141
+    components:
+    - type: Transform
+      pos: -8.5,3.5
+      parent: 2
+- proto: SignSecure
+  entities:
+  - uid: 1142
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,3.5
+      parent: 2
+- proto: SignSecurity
+  entities:
+  - uid: 1143
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,3.5
+      parent: 2
+- proto: SinkWide
+  entities:
+  - uid: 1145
+    components:
+    - type: Transform
+      pos: 10.5,-3.5
+      parent: 2
+  - uid: 1755
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 2
+- proto: SMESBasic
+  entities:
+  - uid: 1146
+    components:
+    - type: Transform
+      pos: 4.5,-14.5
+      parent: 2
+  - uid: 1147
+    components:
+    - type: Transform
+      pos: 4.5,-15.5
+      parent: 2
+- proto: SpawnDungeonLootMugs
+  entities:
+  - uid: 995
+    components:
+    - type: Transform
+      pos: 1.4210275,-6.4261494
+      parent: 2
+  - uid: 996
+    components:
+    - type: Transform
+      pos: -0.53209746,-6.9105244
+      parent: 2
+  - uid: 1263
+    components:
+    - type: Transform
+      pos: 1.2099483,-8.238566
+      parent: 2
+- proto: SpawnDungeonLootPowerCell
+  entities:
+  - uid: 1644
+    components:
+    - type: Transform
+      pos: -0.40817523,5.591854
+      parent: 2
+- proto: SpawnMobBear
+  entities:
+  - uid: 1712
+    components:
+    - type: Transform
+      pos: 7.5,9.5
+      parent: 2
+- proto: SpawnMobSpaceCobra
+  entities:
+  - uid: 1239
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-14.5
+      parent: 2
+- proto: SpawnMobSpaceSpider
+  entities:
+  - uid: 991
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-12.5
+      parent: 2
+  - uid: 1711
+    components:
+    - type: Transform
+      pos: 10.5,7.5
+      parent: 2
+  - uid: 1759
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-15.5
+      parent: 2
+- proto: SpawnPointLatejoin
+  entities:
+  - uid: 1153
+    components:
+    - type: Transform
+      pos: -0.5,-9.5
+      parent: 2
+  - uid: 1154
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 2
+  - uid: 1155
+    components:
+    - type: Transform
+      pos: 1.5,-9.5
+      parent: 2
+  - uid: 1156
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 2
+- proto: SpiderWeb
+  entities:
+  - uid: 690
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-11.5
+      parent: 2
+  - uid: 990
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-7.5
+      parent: 2
+  - uid: 992
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-14.5
+      parent: 2
+  - uid: 993
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-15.5
+      parent: 2
+  - uid: 1008
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-12.5
+      parent: 2
+  - uid: 1009
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-11.5
+      parent: 2
+  - uid: 1012
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-11.5
+      parent: 2
+  - uid: 1013
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-15.5
+      parent: 2
+  - uid: 1122
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-12.5
+      parent: 2
+  - uid: 1164
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-11.5
+      parent: 2
+  - uid: 1165
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-9.5
+      parent: 2
+  - uid: 1174
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-10.5
+      parent: 2
+  - uid: 1175
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-10.5
+      parent: 2
+  - uid: 1178
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-12.5
+      parent: 2
+  - uid: 1179
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-11.5
+      parent: 2
+  - uid: 1182
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,-13.5
+      parent: 2
+  - uid: 1183
+    components:
+    - type: Transform
+      pos: 7.5,7.5
+      parent: 2
+  - uid: 1184
+    components:
+    - type: Transform
+      pos: 10.5,5.5
+      parent: 2
+  - uid: 1185
+    components:
+    - type: Transform
+      pos: 9.5,5.5
+      parent: 2
+  - uid: 1186
+    components:
+    - type: Transform
+      pos: 10.5,5.5
+      parent: 2
+  - uid: 1188
+    components:
+    - type: Transform
+      pos: 11.5,5.5
+      parent: 2
+  - uid: 1189
+    components:
+    - type: Transform
+      pos: 10.5,5.5
+      parent: 2
+  - uid: 1190
+    components:
+    - type: Transform
+      pos: 10.5,5.5
+      parent: 2
+  - uid: 1191
+    components:
+    - type: Transform
+      pos: 10.5,6.5
+      parent: 2
+  - uid: 1192
+    components:
+    - type: Transform
+      pos: 10.5,7.5
+      parent: 2
+  - uid: 1193
+    components:
+    - type: Transform
+      pos: 6.5,11.5
+      parent: 2
+  - uid: 1194
+    components:
+    - type: Transform
+      pos: 6.5,10.5
+      parent: 2
+  - uid: 1195
+    components:
+    - type: Transform
+      pos: 7.5,10.5
+      parent: 2
+  - uid: 1196
+    components:
+    - type: Transform
+      pos: 7.5,11.5
+      parent: 2
+  - uid: 1197
+    components:
+    - type: Transform
+      pos: 8.5,10.5
+      parent: 2
+  - uid: 1198
+    components:
+    - type: Transform
+      pos: 5.5,11.5
+      parent: 2
+  - uid: 1199
+    components:
+    - type: Transform
+      pos: 7.5,11.5
+      parent: 2
+  - uid: 1200
+    components:
+    - type: Transform
+      pos: 7.5,10.5
+      parent: 2
+  - uid: 1201
+    components:
+    - type: Transform
+      pos: 7.5,9.5
+      parent: 2
+  - uid: 1202
+    components:
+    - type: Transform
+      pos: 8.5,9.5
+      parent: 2
+  - uid: 1203
+    components:
+    - type: Transform
+      pos: 9.5,9.5
+      parent: 2
+  - uid: 1204
+    components:
+    - type: Transform
+      pos: 8.5,9.5
+      parent: 2
+  - uid: 1205
+    components:
+    - type: Transform
+      pos: 8.5,10.5
+      parent: 2
+  - uid: 1206
+    components:
+    - type: Transform
+      pos: 8.5,10.5
+      parent: 2
+  - uid: 1207
+    components:
+    - type: Transform
+      pos: 7.5,8.5
+      parent: 2
+  - uid: 1249
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-11.5
+      parent: 2
+  - uid: 1251
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-11.5
+      parent: 2
+  - uid: 1253
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-10.5
+      parent: 2
+  - uid: 1301
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-15.5
+      parent: 2
+  - uid: 1305
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-16.5
+      parent: 2
+  - uid: 1423
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-15.5
+      parent: 2
+  - uid: 1425
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-12.5
+      parent: 2
+  - uid: 1426
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-15.5
+      parent: 2
+  - uid: 1429
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-16.5
+      parent: 2
+  - uid: 1430
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-15.5
+      parent: 2
+  - uid: 1627
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-15.5
+      parent: 2
+  - uid: 1632
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-14.5
+      parent: 2
+  - uid: 1633
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-14.5
+      parent: 2
+  - uid: 1634
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-16.5
+      parent: 2
+  - uid: 1635
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-10.5
+      parent: 2
+  - uid: 1636
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-13.5
+      parent: 2
+  - uid: 1637
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,-14.5
+      parent: 2
+  - uid: 1648
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-12.5
+      parent: 2
+  - uid: 1654
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-8.5
+      parent: 2
+  - uid: 1760
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-13.5
+      parent: 2
+- proto: Stairs
+  entities:
+  - uid: 1208
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 2
+  - uid: 1209
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 2
+  - uid: 1210
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 2
+  - uid: 1211
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 2
+  - uid: 1212
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 2
+  - uid: 1213
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 2
+  - uid: 1214
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-8.5
+      parent: 2
+  - uid: 1215
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-7.5
+      parent: 2
+  - uid: 1216
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-6.5
+      parent: 2
+  - uid: 1217
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-5.5
+      parent: 2
+  - uid: 1218
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-4.5
+      parent: 2
+  - uid: 1219
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-4.5
+      parent: 2
+  - uid: 1220
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-5.5
+      parent: 2
+  - uid: 1221
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-5.5
+      parent: 2
+  - uid: 1222
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-6.5
+      parent: 2
+  - uid: 1223
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-6.5
+      parent: 2
+  - uid: 1224
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-9.5
+      parent: 2
+  - uid: 1225
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-8.5
+      parent: 2
+  - uid: 1226
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-7.5
+      parent: 2
+  - uid: 1227
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-6.5
+      parent: 2
+  - uid: 1228
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-5.5
+      parent: 2
+  - uid: 1229
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-7.5
+      parent: 2
+  - uid: 1230
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-7.5
+      parent: 2
+  - uid: 1231
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-8.5
+      parent: 2
+  - uid: 1232
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-8.5
+      parent: 2
+  - uid: 1233
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-9.5
+      parent: 2
+- proto: StairStage
+  entities:
+  - uid: 1234
+    components:
+    - type: Transform
+      pos: -7.5,-3.5
+      parent: 2
+  - uid: 1235
+    components:
+    - type: Transform
+      pos: 8.5,-3.5
+      parent: 2
+- proto: StoolBar
+  entities:
+  - uid: 699
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-8.5
+      parent: 2
+  - uid: 1743
+    components:
+    - type: Transform
+      pos: -6.5,-7.5
+      parent: 2
+  - uid: 1746
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-7.5
+      parent: 2
+  - uid: 1748
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-9.5
+      parent: 2
+  - uid: 1749
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 2
+  - uid: 1750
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-9.5
+      parent: 2
+  - uid: 1751
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 2
+  - uid: 1752
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-7.5
+      parent: 2
+  - uid: 1753
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-9.5
+      parent: 2
+- proto: StorageCanister
+  entities:
+  - uid: 1803
+    components:
+    - type: Transform
+      pos: -9.5,9.5
+      parent: 2
+- proto: SubstationBasic
+  entities:
+  - uid: 1243
+    components:
+    - type: Transform
+      pos: 5.5,-16.5
+      parent: 2
+- proto: SubstationWallBasic
+  entities:
+  - uid: 1244
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 2
+  - uid: 1245
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,4.5
+      parent: 2
+  - uid: 1246
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 2
+- proto: Table
+  entities:
+  - uid: 986
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,-16.5
+      parent: 2
+  - uid: 1006
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,6.5
+      parent: 2
+  - uid: 1025
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,7.5
+      parent: 2
+  - uid: 1158
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,-15.5
+      parent: 2
+  - uid: 1161
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,-16.5
+      parent: 2
+  - uid: 1650
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-16.5
+      parent: 2
+  - uid: 1757
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-10.5
+      parent: 2
+  - uid: 1758
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-16.5
+      parent: 2
+- proto: TableReinforced
+  entities:
+  - uid: 1254
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,5.5
+      parent: 2
+  - uid: 1255
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,5.5
+      parent: 2
+  - uid: 1256
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,4.5
+      parent: 2
+  - uid: 1257
+    components:
+    - type: Transform
+      pos: 8.5,6.5
+      parent: 2
+  - uid: 1258
+    components:
+    - type: Transform
+      pos: 9.5,6.5
+      parent: 2
+  - uid: 1259
+    components:
+    - type: Transform
+      pos: 9.5,7.5
+      parent: 2
+  - uid: 1260
+    components:
+    - type: Transform
+      pos: 8.5,7.5
+      parent: 2
+  - uid: 1261
+    components:
+    - type: Transform
+      pos: 8.5,8.5
+      parent: 2
+  - uid: 1262
+    components:
+    - type: Transform
+      pos: 9.5,8.5
+      parent: 2
+  - uid: 1744
+    components:
+    - type: Transform
+      pos: 11.5,7.5
+      parent: 2
+  - uid: 1747
+    components:
+    - type: Transform
+      pos: 11.5,6.5
+      parent: 2
+- proto: TableStone
+  entities:
+  - uid: 1790
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,5.5
+      parent: 2
+- proto: TableWoodReinforced
+  entities:
+  - uid: 1050
+    components:
+    - type: Transform
+      pos: -0.5,-7.5
+      parent: 2
+  - uid: 1267
+    components:
+    - type: Transform
+      pos: -0.5,-6.5
+      parent: 2
+  - uid: 1306
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 2
+  - uid: 1307
+    components:
+    - type: Transform
+      pos: 1.5,-8.5
+      parent: 2
+  - uid: 1308
+    components:
+    - type: Transform
+      pos: 1.5,-6.5
+      parent: 2
+  - uid: 1628
+    components:
+    - type: Transform
+      pos: 0.5,-8.5
+      parent: 2
+  - uid: 1630
+    components:
+    - type: Transform
+      pos: -0.5,-8.5
+      parent: 2
+  - uid: 1639
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 2
+  - uid: 1640
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 2
+- proto: Thruster
+  entities:
+  - uid: 1269
+    components:
+    - type: Transform
+      rot: -3.141592653589793 rad
+      pos: -9.5,-18.5
+      parent: 2
+  - uid: 1270
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 2
+  - uid: 1271
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 2
+  - uid: 1272
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,10.5
+      parent: 2
+  - uid: 1273
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,9.5
+      parent: 2
+  - uid: 1274
+    components:
+    - type: Transform
+      rot: -3.141592653589793 rad
+      pos: -8.5,-18.5
+      parent: 2
+  - uid: 1275
+    components:
+    - type: Transform
+      rot: -3.141592653589793 rad
+      pos: -7.5,-18.5
+      parent: 2
+  - uid: 1276
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-14.5
+      parent: 2
+  - uid: 1277
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-15.5
+      parent: 2
+  - uid: 1278
+    components:
+    - type: Transform
+      rot: -3.141592653589793 rad
+      pos: 9.5,-18.5
+      parent: 2
+  - uid: 1279
+    components:
+    - type: Transform
+      rot: -3.141592653589793 rad
+      pos: 10.5,-18.5
+      parent: 2
+  - uid: 1280
+    components:
+    - type: Transform
+      rot: -3.141592653589793 rad
+      pos: 8.5,-18.5
+      parent: 2
+  - uid: 1281
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 2
+  - uid: 1282
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-0.5
+      parent: 2
+  - uid: 1283
+    components:
+    - type: Transform
+      rot: -3.141592653589793 rad
+      pos: -4.5,3.5
+      parent: 2
+  - uid: 1284
+    components:
+    - type: Transform
+      rot: -10.995574287564276 rad
+      pos: -12.5,-15.5
+      parent: 2
+  - uid: 1285
+    components:
+    - type: Transform
+      rot: -10.995574287564276 rad
+      pos: -12.5,-14.5
+      parent: 2
+  - uid: 1286
+    components:
+    - type: Transform
+      rot: -4.71238898038469 rad
+      pos: -11.5,9.5
+      parent: 2
+  - uid: 1287
+    components:
+    - type: Transform
+      rot: -4.71238898038469 rad
+      pos: -11.5,10.5
+      parent: 2
+  - uid: 1288
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 2
+  - uid: 1289
+    components:
+    - type: Transform
+      rot: -3.141592653589793 rad
+      pos: 5.5,3.5
+      parent: 2
+  - uid: 1290
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 2
+  - uid: 1291
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-0.5
+      parent: 2
+  - uid: 1292
+    components:
+    - type: Transform
+      pos: 5.5,-1.5
+      parent: 2
+- proto: ToiletDirtyWater
+  entities:
+  - uid: 1293
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-4.5
+      parent: 2
+  - uid: 1294
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-4.5
+      parent: 2
+  - uid: 1295
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-3.5
+      parent: 2
+- proto: ToolboxElectricalFilled
+  entities:
+  - uid: 1296
+    components:
+    - type: Transform
+      pos: 8.328063,-10.726057
+      parent: 2
+- proto: ToolboxMechanicalFilled
+  entities:
+  - uid: 1297
+    components:
+    - type: Transform
+      pos: 8.311531,-10.517394
+      parent: 2
+- proto: TwoWayLever
+  entities:
+  - uid: 1298
+    components:
+    - type: Transform
+      pos: 0.5,-13.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        200:
+        - Left: Open
+        - Right: Open
+        - Middle: Close
+        201:
+        - Left: Open
+        - Right: Open
+        - Middle: Close
+        202:
+        - Left: Open
+        - Right: Open
+        - Middle: Close
+- proto: VendingMachineBooze
+  entities:
+  - uid: 1167
+    components:
+    - type: Transform
+      pos: -2.5,-10.5
+      parent: 2
+- proto: VendingMachineBountyVend
+  entities:
+  - uid: 1300
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 2
+- proto: VendingMachineClothing
+  entities:
+  - uid: 1302
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 2
+- proto: VendingMachineEngiDrobe
+  entities:
+  - uid: 1303
+    components:
+    - type: Transform
+      pos: 9.5,-9.5
+      parent: 2
+- proto: VendingMachineTankDispenserEVA
+  entities:
+  - uid: 1241
+    components:
+    - type: Transform
+      pos: -1.5,-12.5
+      parent: 2
+  - uid: 1299
+    components:
+    - type: Transform
+      pos: -8.5,0.5
+      parent: 2
+  - uid: 1310
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 2
+- proto: VendingMachineWinter
+  entities:
+  - uid: 1312
+    components:
+    - type: Transform
+      pos: -5.5,-3.5
+      parent: 2
+- proto: VendingMachineYouTool
+  entities:
+  - uid: 1313
+    components:
+    - type: Transform
+      pos: 7.5,-10.5
+      parent: 2
+- proto: WallmountTelevisionFrame
+  entities:
+  - uid: 1787
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,7.5
+      parent: 2
+- proto: WallPlastitanium
+  entities:
+  - uid: 999
+    components:
+    - type: Transform
+      pos: -1.5,12.5
+      parent: 2
+  - uid: 1314
+    components:
+    - type: Transform
+      pos: -9.5,-5.5
+      parent: 2
+  - uid: 1315
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-0.5
+      parent: 2
+  - uid: 1316
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,2.5
+      parent: 2
+  - uid: 1317
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,1.5
+      parent: 2
+  - uid: 1318
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-1.5
+      parent: 2
+  - uid: 1319
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-2.5
+      parent: 2
+  - uid: 1320
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-2.5
+      parent: 2
+  - uid: 1321
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-3.5
+      parent: 2
+  - uid: 1322
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,3.5
+      parent: 2
+  - uid: 1323
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-2.5
+      parent: 2
+  - uid: 1324
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-1.5
+      parent: 2
+  - uid: 1325
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-0.5
+      parent: 2
+  - uid: 1326
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 2
+  - uid: 1327
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,3.5
+      parent: 2
+  - uid: 1328
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,5.5
+      parent: 2
+  - uid: 1329
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,1.5
+      parent: 2
+  - uid: 1330
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,4.5
+      parent: 2
+  - uid: 1331
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,2.5
+      parent: 2
+  - uid: 1332
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 2
+  - uid: 1333
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-2.5
+      parent: 2
+  - uid: 1334
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-3.5
+      parent: 2
+  - uid: 1335
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,5.5
+      parent: 2
+  - uid: 1336
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,4.5
+      parent: 2
+  - uid: 1337
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-4.5
+      parent: 2
+  - uid: 1338
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-2.5
+      parent: 2
+  - uid: 1339
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-3.5
+      parent: 2
+  - uid: 1340
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-17.5
+      parent: 2
+  - uid: 1341
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-3.5
+      parent: 2
+  - uid: 1342
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-11.5
+      parent: 2
+  - uid: 1343
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-1.5
+      parent: 2
+  - uid: 1344
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-1.5
+      parent: 2
+  - uid: 1345
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-4.5
+      parent: 2
+  - uid: 1346
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-0.5
+      parent: 2
+  - uid: 1347
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,1.5
+      parent: 2
+  - uid: 1348
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-0.5
+      parent: 2
+  - uid: 1349
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,1.5
+      parent: 2
+  - uid: 1350
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,2.5
+      parent: 2
+  - uid: 1351
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,5.5
+      parent: 2
+  - uid: 1352
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,4.5
+      parent: 2
+  - uid: 1353
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,5.5
+      parent: 2
+  - uid: 1354
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,3.5
+      parent: 2
+  - uid: 1355
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,6.5
+      parent: 2
+  - uid: 1356
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,7.5
+      parent: 2
+  - uid: 1357
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,8.5
+      parent: 2
+  - uid: 1358
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,9.5
+      parent: 2
+  - uid: 1359
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,9.5
+      parent: 2
+  - uid: 1360
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,10.5
+      parent: 2
+  - uid: 1361
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,14.5
+      parent: 2
+  - uid: 1362
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,13.5
+      parent: 2
+  - uid: 1363
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,10.5
+      parent: 2
+  - uid: 1364
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,12.5
+      parent: 2
+  - uid: 1365
+    components:
+    - type: Transform
+      pos: -10.5,11.5
+      parent: 2
+  - uid: 1366
+    components:
+    - type: Transform
+      pos: -9.5,11.5
+      parent: 2
+  - uid: 1367
+    components:
+    - type: Transform
+      pos: -10.5,12.5
+      parent: 2
+  - uid: 1368
+    components:
+    - type: Transform
+      pos: -9.5,12.5
+      parent: 2
+  - uid: 1369
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,14.5
+      parent: 2
+  - uid: 1370
+    components:
+    - type: Transform
+      pos: -11.5,8.5
+      parent: 2
+  - uid: 1371
+    components:
+    - type: Transform
+      pos: -12.5,6.5
+      parent: 2
+  - uid: 1372
+    components:
+    - type: Transform
+      pos: -12.5,7.5
+      parent: 2
+  - uid: 1373
+    components:
+    - type: Transform
+      pos: -12.5,5.5
+      parent: 2
+  - uid: 1374
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,3.5
+      parent: 2
+  - uid: 1375
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,3.5
+      parent: 2
+  - uid: 1376
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,3.5
+      parent: 2
+  - uid: 1377
+    components:
+    - type: Transform
+      pos: -12.5,-1.5
+      parent: 2
+  - uid: 1378
+    components:
+    - type: Transform
+      pos: -11.5,-5.5
+      parent: 2
+  - uid: 1379
+    components:
+    - type: Transform
+      pos: -8.5,-2.5
+      parent: 2
+  - uid: 1380
+    components:
+    - type: Transform
+      pos: -9.5,-2.5
+      parent: 2
+  - uid: 1381
+    components:
+    - type: Transform
+      pos: -10.5,-2.5
+      parent: 2
+  - uid: 1382
+    components:
+    - type: Transform
+      pos: -11.5,-2.5
+      parent: 2
+  - uid: 1383
+    components:
+    - type: Transform
+      pos: -13.5,-2.5
+      parent: 2
+  - uid: 1384
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-8.5
+      parent: 2
+  - uid: 1385
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-8.5
+      parent: 2
+  - uid: 1386
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-9.5
+      parent: 2
+  - uid: 1387
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-9.5
+      parent: 2
+  - uid: 1388
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,6.5
+      parent: 2
+  - uid: 1389
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,2.5
+      parent: 2
+  - uid: 1390
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,7.5
+      parent: 2
+  - uid: 1391
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,9.5
+      parent: 2
+  - uid: 1392
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,3.5
+      parent: 2
+  - uid: 1393
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,4.5
+      parent: 2
+  - uid: 1394
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,5.5
+      parent: 2
+  - uid: 1395
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-15.5
+      parent: 2
+  - uid: 1396
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-16.5
+      parent: 2
+  - uid: 1397
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-17.5
+      parent: 2
+  - uid: 1398
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-14.5
+      parent: 2
+  - uid: 1399
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-13.5
+      parent: 2
+  - uid: 1400
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-12.5
+      parent: 2
+  - uid: 1401
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,8.5
+      parent: 2
+  - uid: 1402
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 2
+  - uid: 1403
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-14.5
+      parent: 2
+  - uid: 1404
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,13.5
+      parent: 2
+  - uid: 1405
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,13.5
+      parent: 2
+  - uid: 1406
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,13.5
+      parent: 2
+  - uid: 1407
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,12.5
+      parent: 2
+  - uid: 1408
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-9.5
+      parent: 2
+  - uid: 1409
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-10.5
+      parent: 2
+  - uid: 1410
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-11.5
+      parent: 2
+  - uid: 1411
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-12.5
+      parent: 2
+  - uid: 1412
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-11.5
+      parent: 2
+  - uid: 1413
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-15.5
+      parent: 2
+  - uid: 1414
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-15.5
+      parent: 2
+  - uid: 1415
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-18.5
+      parent: 2
+  - uid: 1416
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-17.5
+      parent: 2
+  - uid: 1417
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-17.5
+      parent: 2
+  - uid: 1418
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-17.5
+      parent: 2
+  - uid: 1419
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-17.5
+      parent: 2
+  - uid: 1420
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-17.5
+      parent: 2
+  - uid: 1421
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,9.5
+      parent: 2
+  - uid: 1422
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,12.5
+      parent: 2
+  - uid: 1424
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,13.5
+      parent: 2
+  - uid: 1427
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,13.5
+      parent: 2
+  - uid: 1428
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,13.5
+      parent: 2
+  - uid: 1431
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-9.5
+      parent: 2
+  - uid: 1432
+    components:
+    - type: Transform
+      pos: -12.5,-2.5
+      parent: 2
+  - uid: 1433
+    components:
+    - type: Transform
+      pos: -8.5,-5.5
+      parent: 2
+  - uid: 1434
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,3.5
+      parent: 2
+  - uid: 1435
+    components:
+    - type: Transform
+      pos: -11.5,6.5
+      parent: 2
+  - uid: 1436
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-10.5
+      parent: 2
+  - uid: 1437
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-11.5
+      parent: 2
+  - uid: 1438
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-13.5
+      parent: 2
+  - uid: 1439
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-14.5
+      parent: 2
+  - uid: 1440
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-16.5
+      parent: 2
+  - uid: 1441
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-17.5
+      parent: 2
+  - uid: 1442
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-16.5
+      parent: 2
+  - uid: 1443
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-17.5
+      parent: 2
+  - uid: 1444
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-11.5
+      parent: 2
+  - uid: 1445
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-7.5
+      parent: 2
+  - uid: 1446
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-8.5
+      parent: 2
+  - uid: 1447
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-8.5
+      parent: 2
+  - uid: 1448
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-10.5
+      parent: 2
+  - uid: 1449
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-11.5
+      parent: 2
+  - uid: 1450
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-12.5
+      parent: 2
+  - uid: 1451
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-11.5
+      parent: 2
+  - uid: 1452
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-9.5
+      parent: 2
+  - uid: 1453
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-12.5
+      parent: 2
+  - uid: 1454
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-17.5
+      parent: 2
+  - uid: 1455
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-15.5
+      parent: 2
+  - uid: 1456
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-18.5
+      parent: 2
+  - uid: 1457
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-17.5
+      parent: 2
+  - uid: 1458
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,-17.5
+      parent: 2
+  - uid: 1459
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-16.5
+      parent: 2
+  - uid: 1460
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-17.5
+      parent: 2
+  - uid: 1461
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-17.5
+      parent: 2
+  - uid: 1462
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-17.5
+      parent: 2
+  - uid: 1463
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-17.5
+      parent: 2
+  - uid: 1464
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,-18.5
+      parent: 2
+  - uid: 1465
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,-17.5
+      parent: 2
+  - uid: 1466
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-17.5
+      parent: 2
+  - uid: 1467
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-16.5
+      parent: 2
+  - uid: 1468
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-14.5
+      parent: 2
+  - uid: 1469
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-15.5
+      parent: 2
+  - uid: 1470
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-13.5
+      parent: 2
+  - uid: 1471
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-12.5
+      parent: 2
+  - uid: 1472
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,-11.5
+      parent: 2
+  - uid: 1473
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,-12.5
+      parent: 2
+  - uid: 1474
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-13.5
+      parent: 2
+  - uid: 1475
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-10.5
+      parent: 2
+  - uid: 1476
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-10.5
+      parent: 2
+  - uid: 1477
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-9.5
+      parent: 2
+  - uid: 1478
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-9.5
+      parent: 2
+  - uid: 1479
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-9.5
+      parent: 2
+  - uid: 1480
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-8.5
+      parent: 2
+  - uid: 1481
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-8.5
+      parent: 2
+  - uid: 1482
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,-8.5
+      parent: 2
+  - uid: 1483
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,-9.5
+      parent: 2
+  - uid: 1484
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,-10.5
+      parent: 2
+  - uid: 1485
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-8.5
+      parent: 2
+  - uid: 1486
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-9.5
+      parent: 2
+  - uid: 1487
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-16.5
+      parent: 2
+  - uid: 1488
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-7.5
+      parent: 2
+  - uid: 1489
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-6.5
+      parent: 2
+  - uid: 1490
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-5.5
+      parent: 2
+  - uid: 1491
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,-4.5
+      parent: 2
+  - uid: 1492
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,-3.5
+      parent: 2
+  - uid: 1493
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,-2.5
+      parent: 2
+  - uid: 1494
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,-1.5
+      parent: 2
+  - uid: 1495
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,2.5
+      parent: 2
+  - uid: 1496
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,0.5
+      parent: 2
+  - uid: 1497
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,2.5
+      parent: 2
+  - uid: 1498
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,0.5
+      parent: 2
+  - uid: 1499
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,3.5
+      parent: 2
+  - uid: 1500
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,4.5
+      parent: 2
+  - uid: 1501
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,5.5
+      parent: 2
+  - uid: 1502
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,7.5
+      parent: 2
+  - uid: 1503
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,8.5
+      parent: 2
+  - uid: 1504
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,3.5
+      parent: 2
+  - uid: 1505
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,-5.5
+      parent: 2
+  - uid: 1506
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,-2.5
+      parent: 2
+  - uid: 1507
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,3.5
+      parent: 2
+  - uid: 1508
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,6.5
+      parent: 2
+  - uid: 1509
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,7.5
+      parent: 2
+  - uid: 1510
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,11.5
+      parent: 2
+  - uid: 1511
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,11.5
+      parent: 2
+  - uid: 1512
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,12.5
+      parent: 2
+  - uid: 1513
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,12.5
+      parent: 2
+  - uid: 1514
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,12.5
+      parent: 2
+  - uid: 1515
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,2.5
+      parent: 2
+  - uid: 1516
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,2.5
+      parent: 2
+  - uid: 1517
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-2.5
+      parent: 2
+  - uid: 1518
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,3.5
+      parent: 2
+  - uid: 1519
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,-1.5
+      parent: 2
+  - uid: 1520
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-4.5
+      parent: 2
+  - uid: 1521
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,0.5
+      parent: 2
+  - uid: 1522
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,3.5
+      parent: 2
+  - uid: 1523
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,3.5
+      parent: 2
+  - uid: 1524
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,3.5
+      parent: 2
+  - uid: 1525
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-2.5
+      parent: 2
+  - uid: 1526
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,-2.5
+      parent: 2
+  - uid: 1527
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,3.5
+      parent: 2
+  - uid: 1528
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-4.5
+      parent: 2
+  - uid: 1529
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,-2.5
+      parent: 2
+  - uid: 1530
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-2.5
+      parent: 2
+  - uid: 1531
+    components:
+    - type: Transform
+      pos: -12.5,-3.5
+      parent: 2
+  - uid: 1532
+    components:
+    - type: Transform
+      pos: -13.5,0.5
+      parent: 2
+  - uid: 1533
+    components:
+    - type: Transform
+      pos: -12.5,0.5
+      parent: 2
+  - uid: 1534
+    components:
+    - type: Transform
+      pos: -11.5,0.5
+      parent: 2
+  - uid: 1535
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-2.5
+      parent: 2
+  - uid: 1536
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,4.5
+      parent: 2
+  - uid: 1537
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,2.5
+      parent: 2
+  - uid: 1538
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-1.5
+      parent: 2
+  - uid: 1539
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-15.5
+      parent: 2
+  - uid: 1540
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,2.5
+      parent: 2
+  - uid: 1541
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-5.5
+      parent: 2
+  - uid: 1542
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,-5.5
+      parent: 2
+  - uid: 1544
+    components:
+    - type: Transform
+      pos: -12.5,-5.5
+      parent: 2
+  - uid: 1545
+    components:
+    - type: Transform
+      pos: -11.5,-6.5
+      parent: 2
+  - uid: 1546
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,3.5
+      parent: 2
+  - uid: 1547
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-18.5
+      parent: 2
+  - uid: 1548
+    components:
+    - type: Transform
+      pos: -12.5,-4.5
+      parent: 2
+  - uid: 1549
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-2.5
+      parent: 2
+  - uid: 1550
+    components:
+    - type: Transform
+      pos: -11.5,-1.5
+      parent: 2
+  - uid: 1551
+    components:
+    - type: Transform
+      pos: -13.5,-1.5
+      parent: 2
+  - uid: 1552
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-1.5
+      parent: 2
+  - uid: 1553
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-1.5
+      parent: 2
+  - uid: 1554
+    components:
+    - type: Transform
+      pos: -10.5,9.5
+      parent: 2
+  - uid: 1555
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,10.5
+      parent: 2
+  - uid: 1556
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,12.5
+      parent: 2
+  - uid: 1557
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,11.5
+      parent: 2
+  - uid: 1558
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,9.5
+      parent: 2
+  - uid: 1559
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,6.5
+      parent: 2
+  - uid: 1560
+    components:
+    - type: Transform
+      pos: -10.5,10.5
+      parent: 2
+  - uid: 1561
+    components:
+    - type: Transform
+      pos: -11.5,11.5
+      parent: 2
+  - uid: 1562
+    components:
+    - type: Transform
+      pos: -11.5,7.5
+      parent: 2
+  - uid: 1563
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,12.5
+      parent: 2
+  - uid: 1664
+    components:
+    - type: Transform
+      pos: 2.5,12.5
+      parent: 2
+  - uid: 1665
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 2
+  - uid: 1671
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 2
+- proto: WallPlastitaniumDiagonal
+  entities:
+  - uid: 1564
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -12.5,-6.5
+      parent: 2
+  - uid: 1565
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,12.5
+      parent: 2
+  - uid: 1566
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 2
+  - uid: 1567
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,3.5
+      parent: 2
+  - uid: 1568
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-2.5
+      parent: 2
+  - uid: 1569
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-2.5
+      parent: 2
+  - uid: 1570
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-4.5
+      parent: 2
+  - uid: 1571
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,6.5
+      parent: 2
+  - uid: 1572
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 2
+  - uid: 1573
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-4.5
+      parent: 2
+  - uid: 1574
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-17.5
+      parent: 2
+  - uid: 1575
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,12.5
+      parent: 2
+  - uid: 1576
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-4.5
+      parent: 2
+  - uid: 1577
+    components:
+    - type: Transform
+      pos: -4.5,10.5
+      parent: 2
+  - uid: 1578
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,12.5
+      parent: 2
+  - uid: 1579
+    components:
+    - type: Transform
+      pos: 4.5,-3.5
+      parent: 2
+  - uid: 1580
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-3.5
+      parent: 2
+  - uid: 1581
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,4.5
+      parent: 2
+  - uid: 1582
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,10.5
+      parent: 2
+  - uid: 1583
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,8.5
+      parent: 2
+  - uid: 1584
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,8.5
+      parent: 2
+  - uid: 1585
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,14.5
+      parent: 2
+  - uid: 1586
+    components:
+    - type: Transform
+      pos: -11.5,12.5
+      parent: 2
+  - uid: 1587
+    components:
+    - type: Transform
+      pos: -6.5,14.5
+      parent: 2
+  - uid: 1588
+    components:
+    - type: Transform
+      pos: -13.5,4.5
+      parent: 2
+  - uid: 1589
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,8.5
+      parent: 2
+  - uid: 1590
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -13.5,-3.5
+      parent: 2
+  - uid: 1591
+    components:
+    - type: Transform
+      pos: -11.5,-11.5
+      parent: 2
+  - uid: 1592
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,4.5
+      parent: 2
+  - uid: 1593
+    components:
+    - type: Transform
+      pos: -8.5,13.5
+      parent: 2
+  - uid: 1594
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-9.5
+      parent: 2
+  - uid: 1595
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -12.5,-16.5
+      parent: 2
+  - uid: 1596
+    components:
+    - type: Transform
+      pos: -12.5,-13.5
+      parent: 2
+  - uid: 1597
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-18.5
+      parent: 2
+  - uid: 1598
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-18.5
+      parent: 2
+  - uid: 1599
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,4.5
+      parent: 2
+  - uid: 1600
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,8.5
+      parent: 2
+  - uid: 1601
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,12.5
+      parent: 2
+  - uid: 1602
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,12.5
+      parent: 2
+  - uid: 1603
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-8.5
+      parent: 2
+  - uid: 1604
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-9.5
+      parent: 2
+  - uid: 1605
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-18.5
+      parent: 2
+  - uid: 1606
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-17.5
+      parent: 2
+  - uid: 1607
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-18.5
+      parent: 2
+  - uid: 1608
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-13.5
+      parent: 2
+  - uid: 1609
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-11.5
+      parent: 2
+  - uid: 1610
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-16.5
+      parent: 2
+  - uid: 1611
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-9.5
+      parent: 2
+  - uid: 1612
+    components:
+    - type: Transform
+      pos: 4.5,14.5
+      parent: 2
+  - uid: 1613
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-3.5
+      parent: 2
+  - uid: 1614
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-6.5
+      parent: 2
+  - uid: 1615
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,14.5
+      parent: 2
+  - uid: 1616
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,13.5
+      parent: 2
+  - uid: 1617
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-4.5
+      parent: 2
+  - uid: 1618
+    components:
+    - type: Transform
+      pos: 7.5,-8.5
+      parent: 2
+  - uid: 1619
+    components:
+    - type: Transform
+      pos: 4.5,-9.5
+      parent: 2
+  - uid: 1620
+    components:
+    - type: Transform
+      pos: -12.5,8.5
+      parent: 2
+  - uid: 1621
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,8.5
+      parent: 2
+  - uid: 1622
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,1.5
+      parent: 2
+  - uid: 1623
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-0.5
+      parent: 2
+  - uid: 1624
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,1.5
+      parent: 2
+  - uid: 1625
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 2
+  - uid: 1659
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,13.5
+      parent: 2
+  - uid: 1663
+    components:
+    - type: Transform
+      pos: -1.5,13.5
+      parent: 2
+  - uid: 1666
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,9.5
+      parent: 2
+  - uid: 1670
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,9.5
+      parent: 2
+- proto: WallWeaponCapacitorRecharger
+  entities:
+  - uid: 1268
+    components:
+    - type: Transform
+      pos: 12.5,7.5
+      parent: 2
+  - uid: 1713
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 2
+- proto: WarpPointShip
+  entities:
+  - uid: 1152
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 2
+- proto: WeaponCapacitorRecharger
+  entities:
+  - uid: 1248
+    components:
+    - type: Transform
+      pos: 8.5,7.5
+      parent: 2
+- proto: WeaponCrusher
+  entities:
+  - uid: 1643
+    components:
+    - type: Transform
+      pos: 2.448414,-13.40642
+      parent: 2
+- proto: WeaponCrusherGlaive
+  entities:
+  - uid: 1642
+    components:
+    - type: Transform
+      pos: 2.6220253,-13.580031
+      parent: 2
+- proto: WeaponDisabler
+  entities:
+  - uid: 697
+    components:
+    - type: Transform
+      pos: 11.518778,7.158044
+      parent: 2
+  - uid: 1732
+    components:
+    - type: Transform
+      pos: 11.518778,6.673669
+      parent: 2
+- proto: WeaponLaserCarbinePractice
+  entities:
+  - uid: 1808
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.243226,5.4934597
+      parent: 2
+- proto: WeaponPistolCHIMP
+  entities:
+  - uid: 1543
+    components:
+    - type: Transform
+      parent: 1745
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: WeaponShotgunSawn
+  entities:
+  - uid: 988
+    components:
+    - type: Transform
+      parent: 987
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 989
+    components:
+    - type: Transform
+      parent: 987
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1187
+    components:
+    - type: Transform
+      parent: 1745
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: WindoorSecure
+  entities:
+  - uid: 1710
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,3.5
+      parent: 2
+  - uid: 1775
+    components:
+    - type: Transform
+      pos: -6.5,3.5
+      parent: 2
+- proto: WindowReinforcedDirectional
+  entities:
+  - uid: 994
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-10.5
+      parent: 2
+  - uid: 1003
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-16.5
+      parent: 2
+  - uid: 1163
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-16.5
+      parent: 2
+  - uid: 1626
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,3.5
+      parent: 2
+  - uid: 1649
+    components:
+    - type: Transform
+      pos: -7.5,-12.5
+      parent: 2
+  - uid: 1655
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-13.5
+      parent: 2
+  - uid: 1721
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-10.5
+      parent: 2
+  - uid: 1735
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,4.5
+      parent: 2
+  - uid: 1739
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,11.5
+      parent: 2
+  - uid: 1782
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,8.5
+      parent: 2
+  - uid: 1783
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,8.5
+      parent: 2
+  - uid: 1784
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,8.5
+      parent: 2
+  - uid: 1786
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,3.5
+      parent: 2
+  - uid: 1793
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,4.5
+      parent: 2
+- proto: XenoWardingTower
+  entities:
+  - uid: 1797
+    components:
+    - type: Transform
+      pos: -5.5,9.5
+      parent: 2
+...

--- a/Resources/Prototypes/Corvax/Entities/Objects/Misc/rubber_stamp.yml
+++ b/Resources/Prototypes/Corvax/Entities/Objects/Misc/rubber_stamp.yml
@@ -1,0 +1,12 @@
+- type: entity
+  name: Печать Vitezstvi
+  parent: RubberStampBase
+  id: RubberStampVitezstvi
+  suffix: НЕ МАППИТЬ!
+  components:
+  - type: Stamp
+    stampedName: Vitezstvi
+    stampedColor: "#5e1010"
+    stampState: "paper_stamp-warden"
+  - type: Sprite
+    state: stamp-warden

--- a/Resources/Prototypes/Corvax/Events/events_bluespace.yml
+++ b/Resources/Prototypes/Corvax/Events/events_bluespace.yml
@@ -24,7 +24,7 @@
       - /Maps/Corvax/Bluespace/RuinedCrescent.yml #Corvax-Frontier
       - /Maps/Corvax/Bluespace/RuinedInv.yml #Corvax-Frontier
       - /Maps/Corvax/Bluespace/RuinedSprinter.yml #Corvax-Frontier
-    rewardFactor: 0.5 # Filler to make the bank go up
+    rewardFactor: 0.1 # Filler to make the bank go up
 
 - type: entity
   id: BluespaceSyndicateFTLRepeater
@@ -45,4 +45,4 @@
   - type: BluespaceErrorRule
     gridPaths:
       - /Maps/Corvax/Bluespace/epsilon.yml
-    rewardFactor: 0.3 # Filler to make the bank go up
+    rewardFactor: 0.01 # Filler to make the bank go up

--- a/Resources/Prototypes/Corvax/Shipyard/Expedition/zaryaA.yml
+++ b/Resources/Prototypes/Corvax/Shipyard/Expedition/zaryaA.yml
@@ -1,0 +1,28 @@
+- type: vessel
+  id: ZaryaА
+  name: VT-A Заря # Vitezstvi Military Force
+  description: Боевое судно Заря, произведено частной военно-производственной компаний Vitezstvi. Рекомендуемый состав команды 3-8 человек.
+  price: 157500 # 50% tax
+  category: Large
+  group: Expedition
+  shuttlePath: /Maps/Corvax/Shuttles/Expedition/ZaryaAssault.yml
+
+- type: gameMap
+  id: ZaryaА
+  mapName: 'VT-A Заря'
+  mapPath: /Maps/Corvax/Shuttles/Expedition/ZaryaAssault.yml
+  minPlayers: 0
+  stations:
+    ZaryaА:
+      stationProto: StandardFrontierExpeditionVessel
+      components:
+        - type: StationNameSetup
+          mapNameTemplate: 'VT-A Заря {1}'
+          nameGenerator:
+            !type:NanotrasenNameGenerator
+            prefixCreator: '14'
+        - type: StationJobs
+          availableJobs:
+            Contractor: [ 0, 0 ]
+            Pilot: [ 0, 0 ]
+            Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/Corvax/Shipyard/Expedition/zaryaR.yml
+++ b/Resources/Prototypes/Corvax/Shipyard/Expedition/zaryaR.yml
@@ -1,0 +1,28 @@
+- type: vessel
+  id: ZaryaR
+  name: VT-R Заря # Vitezstvi Military Force
+  description: Исследовательское версия боевого шаттла Заря. Рекомендуемый состав команды 3-8 человек.
+  price: 125000 # 35% tax
+  category: Large
+  group: Expedition
+  shuttlePath: /Maps/Corvax/Shuttles/Expedition/ZaryaResearch.yml
+
+- type: gameMap
+  id: ZaryaR
+  mapName: 'VT-R Заря'
+  mapPath: /Maps/Corvax/Shuttles/Expedition/ZaryaResearch.yml
+  minPlayers: 0
+  stations:
+    ZaryaR:
+      stationProto: StandardFrontierExpeditionVessel
+      components:
+        - type: StationNameSetup
+          mapNameTemplate: 'VT-R Заря {1}'
+          nameGenerator:
+            !type:NanotrasenNameGenerator
+            prefixCreator: '14'
+        - type: StationJobs
+          availableJobs:
+            Contractor: [ 0, 0 ]
+            Pilot: [ 0, 0 ]
+            Mercenary: [ 0, 0 ]


### PR DESCRIPTION
Возвращение Зари в двух экзепляров:
### Vitezstvi Technology - Assault (VT-A Заря) - Боевое судно Zarya, произведено частной военно-производственной компаний Vitezstvi. Рекомендуемый состав команды 3-8 человек.
- Вырезан медблок
- РНД отдел заменён на оружейный цех
- Добавлено 2 корабельных орудия Трофи в носовую часть корабля управляемые через кнопку у консоли пилота
- Улучшено вооружение в комнате наемников
- Цена такого шаттла - 157 500 кредитов (при продаже ~85 000 кредитов)
![изображение](https://github.com/user-attachments/assets/1b2af52d-957c-4638-9ec0-a224a6e0c347)
### Vitezstvi Technology - Research (VT-R Заря) - Исследовательское версия боевого шаттла Заря. Рекомендуемый состав команды 3-8 человек.
- Вырезан медблок
- Корректировка вооружения в комнате наемников
- Улучшен и украшен РНД отдел
- Цена такого шаттла - 125 000 кредитов (при продаже ~85 000 кредитов)
![изображение](https://github.com/user-attachments/assets/89a4a883-ff97-4989-ab4b-804fb3b5c841)

### Прочие исправления и добавления
- Начисление денег для Фронтиры с ивента, слишком большая сумма выходило за это. Поэтому теперь Фронтиру не начисляют миллионы денег.
- Добавлена новая печать Vitezstvi.