### PR TITLE
Зоны на радаре

### DIFF
--- a/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
@@ -150,6 +150,7 @@ public sealed partial class ShuttleNavControl : BaseShuttleControl
 
         DrawBacking(handle);
         DrawCircles(handle);
+        DrawZoneCircles(handle); // Corvax-Frontier-Zones
 
         // No data
         if (_coordinates == null || _rotation == null)
@@ -422,6 +423,30 @@ public sealed partial class ShuttleNavControl : BaseShuttleControl
             // End Frontier
         }
     }
+
+    // Corvax-Frontier-Zones-start
+    private void DrawZoneCircles(DrawingHandleScreen handle)
+    {
+        if (_coordinates == null || _rotation == null)
+            return;
+
+        var shuttleMapPos = _transform.ToMapCoordinates(_coordinates.Value);
+        var toWorldCenter = -shuttleMapPos.Position;
+        var radarPos = MidPointVector + toWorldCenter * MinimapScale;
+
+        radarPos.Y = Height - radarPos.Y;
+
+        DrawZoneCircle(handle, radarPos, 200, new Color(0, 255, 0, 1));
+        DrawZoneCircle(handle, radarPos, 4500, new Color(255, 255, 0, 1));
+        DrawZoneCircle(handle, radarPos, 12000, new Color(255, 0, 0, 1));
+    }
+
+    private void DrawZoneCircle(DrawingHandleScreen handle, Vector2 center, float radius, Color color)
+    {
+        handle.DrawCircle(center, radius * MinimapScale, color);
+        handle.DrawCircle(center, radius * MinimapScale, color.WithAlpha(150), false);
+    }
+    // Corvax-Frontier-Zones-end
 
     private Vector2 InverseScalePosition(Vector2 value)
     {


### PR DESCRIPTION
# Описание
### _Мяу_

Данный ПР добавляет в радар управления видимые 3 круга, которые в свою очередь означают ингейм игровую зону
- От 0 до 200 - зеленая зона, на ней находится аванпост фронтира, все логично.
- От 200 до 4500 - желтая зона, она после зеленой.
- От 4500 до 12000 - красная зона, опасность!
_P.S. То что после 12000 нету круга ничего не значит, там дальше по прежнему находится красная зона, просто сам по себе космос бесконечно бесконечен._

# Медиа

## Сами круги

![Content Client_OXZTFeYK7J](https://github.com/user-attachments/assets/3db26797-4da6-42cc-8e37-232cd0b09179)
![Content Client_1HIeOAsU5l](https://github.com/user-attachments/assets/6ee2efa0-cb2e-4e41-b3ed-33f1f127de01)

## Фронтир
![image](https://github.com/user-attachments/assets/0713dd6c-2f76-4022-8e82-feab887a8624)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added visual zone indicators to the shuttle radar UI, displaying three concentric circles in green, yellow, and red to represent different spatial zones around the shuttle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->